### PR TITLE
Update TcpController

### DIFF
--- a/flow/src/main/scala/org/alephium/flow/client/Node.scala
+++ b/flow/src/main/scala/org/alephium/flow/client/Node.scala
@@ -92,7 +92,7 @@ object Node {
       ActorRefT
         .build[TcpController.Command](
           system,
-          TcpController.props(config.network.bindAddress, discoveryServer, misbehaviorManager))
+          TcpController.props(config.network.bindAddress, misbehaviorManager))
 
     val eventBus: ActorRefT[EventBus.Message] =
       ActorRefT.build[EventBus.Message](system, EventBus.props())

--- a/flow/src/main/scala/org/alephium/flow/network/InterCliqueManager.scala
+++ b/flow/src/main/scala/org/alephium/flow/network/InterCliqueManager.scala
@@ -65,7 +65,7 @@ object InterCliqueManager {
     }
   }
 
-  final case class PeerDisconnected(peer: InetSocketAddress) extends EventStream.Event
+  final case class PeerDisconnected(peer: InetSocketAddress)
 }
 
 class InterCliqueManager(selfCliqueInfo: CliqueInfo,

--- a/flow/src/main/scala/org/alephium/flow/network/IntraCliqueManager.scala
+++ b/flow/src/main/scala/org/alephium/flow/network/IntraCliqueManager.scala
@@ -69,7 +69,9 @@ class IntraCliqueManager(cliqueInfo: CliqueInfo,
                                                 allHandlers,
                                                 ActorRefT[CliqueManager.Command](self),
                                                 blockFlowSynchronizer)
-        context.actorOf(props)
+        val outbound = context.actorOf(props)
+        context.watch(outbound)
+        ()
       }
     }
 
@@ -99,14 +101,14 @@ class IntraCliqueManager(cliqueInfo: CliqueInfo,
                                      allHandlers,
                                      ActorRefT[CliqueManager.Command](self),
                                      blockFlowSynchronizer)
-        context.actorOf(props)
+        val inbound = context.actorOf(props)
+        context.watch(inbound)
         ()
       }
     case CliqueManager.HandShaked(brokerInfo, _) =>
       log.debug(s"Start syncing with intra-clique node: ${brokerInfo.address}")
       if (brokerInfo.cliqueId == cliqueInfo.id && !brokers.contains(brokerInfo.brokerId)) {
         log.debug(s"Broker connected: $brokerInfo")
-        context watch sender()
         val brokerHandler = ActorRefT[BrokerHandler.Command](sender())
         val newBrokers    = brokers + (brokerInfo.brokerId -> (brokerInfo -> brokerHandler))
         checkAllSynced(newBrokers)

--- a/flow/src/main/scala/org/alephium/flow/network/bootstrap/Broker.scala
+++ b/flow/src/main/scala/org/alephium/flow/network/bootstrap/Broker.scala
@@ -96,7 +96,7 @@ class Broker(bootstrapper: ActorRefT[Bootstrapper.Command])(implicit brokerConfi
     case Tcp.CommandFailed(c: Tcp.Connect) =>
       val current = TimeStamp.now()
       if (current isBefore until) {
-        scheduleOnce(self, Broker.Retry, Duration.ofSecondsUnsafe(2))
+        scheduleOnce(self, Broker.Retry, Duration.ofSecondsUnsafe(1))
         ()
       } else {
         log.info(s"Cannot connect to ${c.remoteAddress}, shutdown the system")

--- a/flow/src/test/scala/org/alephium/flow/network/TcpControllerSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/network/TcpControllerSpec.scala
@@ -35,8 +35,7 @@ class TcpControllerSpec extends AlephiumActorSpec("TcpController") with Alephium
 
     val bindAddress = SocketUtil.temporaryServerAddress()
     val controller =
-      TestActorRef[TcpController](
-        TcpController.props(bindAddress, discoveryServer.ref, misbehaviorManager.ref))
+      TestActorRef[TcpController](TcpController.props(bindAddress, misbehaviorManager.ref))
     val controllerActor = controller.underlyingActor
 
     controller ! TcpController.Start(bootstrapper.ref)
@@ -113,8 +112,10 @@ class TcpControllerSpec extends AlephiumActorSpec("TcpController") with Alephium
     }
   }
 
-  it should "notice the discovery server in case of command failed " in new Fixture {
-    controller ! Tcp.CommandFailed(Tcp.Connect(bindAddress))
-    discoveryServer.expectMsg(DiscoveryServer.Remove(bindAddress))
+  it should "forward connection failure" in new Fixture {
+    val freeAddress = SocketUtil.temporaryServerAddress()
+    val probe       = TestProbe()
+    controller ! TcpController.ConnectTo(freeAddress, probe.ref)
+    probe.expectMsgType[Tcp.CommandFailed]
   }
 }


### PR DESCRIPTION
With this commit, TcpController will forward failures to the connection
initializer, which could retry to connect if needed