### PR TITLE
Fix shutdown test

### DIFF
--- a/app/src/it/scala/org/alephium/app/ShutdownTest.scala
+++ b/app/src/it/scala/org/alephium/app/ShutdownTest.scala
@@ -22,6 +22,7 @@ import akka.actor.Terminated
 import akka.io.{IO, Tcp}
 import akka.testkit.TestProbe
 
+import org.alephium.api.model.SelfClique
 import org.alephium.util._
 
 class ShutdownTest extends AlephiumSpec {
@@ -41,7 +42,8 @@ class ShutdownTest extends AlephiumSpec {
     val server1 = bootNode(publicPort = generatePort, brokerId = 1)
     Seq(server0.start(), server1.start()).foreach(_.futureValue is ())
 
-    Thread.sleep(1000) // wait until children are created
+    eventually(request[SelfClique](getSelfClique).synced is true)
+
     server0.stop().futureValue is ()
     server1.system.whenTerminated.futureValue is a[Terminated]
   }

--- a/flow/src/main/resources/system_it.conf.tmpl
+++ b/flow/src/main/resources/system_it.conf.tmpl
@@ -63,7 +63,7 @@ alephium {
     network-type = "testnet"
 
     ping-frequency = 1 second
-    retry-timeout = 30 second
+    retry-timeout = 10 second
     connection-buffer-capacity-in-byte = 100000000
 
     upnp {

--- a/flow/src/main/resources/system_test.conf.tmpl
+++ b/flow/src/main/resources/system_test.conf.tmpl
@@ -19,7 +19,7 @@ alephium {
     network-type = "devnet"
 
     ping-frequency = 300 second
-    retry-timeout = 30 second
+    retry-timeout = 10 second
     connection-buffer-capacity-in-byte = 100000000
 
     upnp {


### PR DESCRIPTION
The it test is flaky as the retry timeout is too big, so the node does
not know if its peer is down