### PR TITLE
Increase ping frequency for integration tests

### DIFF
--- a/flow/src/main/resources/system_it.conf.tmpl
+++ b/flow/src/main/resources/system_it.conf.tmpl
@@ -21,7 +21,7 @@ alephium {
     max-outbound-connections-per-group = 10
     max-inbound-connections-per-group = 40
 
-    ping-frequency = 1 second
+    ping-frequency = 5 second
     retry-timeout = 10 second
     connection-buffer-capacity-in-byte = 100000000
 

--- a/flow/src/main/scala/org/alephium/flow/network/broker/BrokerHandler.scala
+++ b/flow/src/main/scala/org/alephium/flow/network/broker/BrokerHandler.scala
@@ -181,7 +181,7 @@ trait BrokerHandler extends BaseActor with EventStream.Publisher with FlowDataHa
 
   def sendPing(): Unit = {
     if (pingNonce != 0) {
-      log.debug("No Pong message received in time")
+      log.info(s"No Pong message received in time from $remoteAddress, stopping the brokerHandler")
       publishEvent(MisbehaviorManager.RequestTimeout(remoteAddress))
       context stop self // stop it manually
     } else {
@@ -220,6 +220,9 @@ trait BrokerHandler extends BaseActor with EventStream.Publisher with FlowDataHa
   override def unhandled(message: Any): Unit =
     message match {
       case Terminated(_) =>
+        log.info(
+          s"Connection handler for $remoteAddress is terminated. Stopping the broker handler."
+        )
         context stop self
       case _ => super.unhandled(message)
     }


### PR DESCRIPTION
The 1 second ping frequency can make integration test flaky when
pong message cannot arrive in 1 second. 5 seconds should be fine.

Note that the default value is 300 seconds in production.
Bitcoin uses this value if I recall it correctly.