### PR TITLE
Fix `TimeInterval` validation

### DIFF
--- a/api/src/main/scala/org/alephium/api/Endpoints.scala
+++ b/api/src/main/scala/org/alephium/api/Endpoints.scala
@@ -49,15 +49,6 @@ trait Endpoints
   private val timeIntervalQuery: EndpointInput[TimeInterval] =
     query[TimeStamp]("fromTs")
       .and(query[TimeStamp]("toTs"))
-      .validate(
-        Validator.custom({ case (from, to) =>
-          if (from > to) {
-            List(ValidationError.Custom((from, to), "`fromTs` must be before `toTs`"))
-          } else {
-            List.empty
-          }
-        })
-      )
       .map({ case (from, to) => TimeInterval(from, to) })(timeInterval =>
         (timeInterval.from, timeInterval.to)
       )

--- a/app/src/main/scala/org/alephium/app/RestServer.scala
+++ b/app/src/main/scala/org/alephium/app/RestServer.scala
@@ -156,9 +156,17 @@ class RestServer(
   }
 
   private val getBlockflowRoute = toRoute(getBlockflow) { timeInterval =>
-    Future.successful(
-      serverUtils.getBlockflow(blockFlow, FetchRequest(timeInterval.from, timeInterval.to))
-    )
+    //TODO Validation can be moved to the `EndpointInput[TimeInterval]` once
+    //we update tapir to 0.18.0
+    if (timeInterval.from > timeInterval.to) {
+      Future.successful(
+        Left(ApiError.BadRequest(s"`fromTs` must be before `toTs`"))
+      )
+    } else {
+      Future.successful(
+        serverUtils.getBlockflow(blockFlow, FetchRequest(timeInterval.from, timeInterval.to))
+      )
+    }
   }
 
   private val getBlockRoute = toRoute(getBlock) { hash =>

--- a/app/src/test/scala/org/alephium/app/RestServerSpec.scala
+++ b/app/src/test/scala/org/alephium/app/RestServerSpec.scala
@@ -57,10 +57,10 @@ class RestServerSpec extends AlephiumFutureSpec with EitherValues with NumericHe
         response.as[FetchResponse] is dummyFetchResponse
       }
 
-      Get(s"/blockflow?fromTs=10&toTs=0}") check { response =>
+      Get(s"/blockflow?fromTs=10&toTs=0") check { response =>
         response.code is StatusCode.BadRequest
         response.as[ApiError.BadRequest] is ApiError.BadRequest(
-          """Invalid value for: query parameter toTs (For input string: "0}": 0})"""
+          """`fromTs` must be before `toTs`"""
         )
       }
     }


### PR DESCRIPTION
It seems there's a bug in tapir v0.17 where the custom validation
doesn't work from an `EndpointIO.Pair`.

This quick fix will be used until we upgrade at `v0.18`