### PR TITLE
Build docker containers for testnet

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -154,6 +154,8 @@ lazy val app = mainProject("app")
       val artifact: File     = assembly.value
       val artifactTargetPath = "/alephium.jar"
 
+      val userConf: File     = file("docker/user-testnet.conf")
+
       val alephiumHome = "/alephium-home"
 
       new Dockerfile {
@@ -162,15 +164,18 @@ lazy val app = mainProject("app")
         // Uncomment the next line and comment the previous one if you want to use GraalVM instead of OpenJDK
         // from("ghcr.io/graalvm/graalvm-ce:java11-21.0.0.2")
 
-        add(artifact, artifactTargetPath)
-
         runRaw(
-          s"mkdir -p $alephiumHome && usermod -d $alephiumHome nobody && chown nobody $alephiumHome"
+          Seq(
+            s"mkdir -p $alephiumHome && usermod -d $alephiumHome nobody && chown nobody $alephiumHome",
+            s"mkdir -p $alephiumHome/.alephium && chown nobody $alephiumHome/.alephium",
+            s"mkdir -p $alephiumHome/.alephium-wallets && chown nobody $alephiumHome/.alephium-wallets"
+          ).mkString(" && ")
         )
         workDir(alephiumHome)
 
-        runRaw("mkdir -p .alephium && chown nobody .alephium")
-        runRaw("mkdir -p .alephium-wallets && chown nobody .alephium-wallets")
+        copy(userConf, file(s"$alephiumHome/.alephium/user.conf"))
+
+        copy(artifact, artifactTargetPath)
 
         expose(12973) // http
         expose(11973) // ws

--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,7 @@ lazy val app = mainProject("app")
       val artifact: File     = assembly.value
       val artifactTargetPath = "/alephium.jar"
 
-      val userConf: File     = file("docker/user-testnet.conf")
+      val userConf: File = file("docker/user-testnet.conf")
 
       val alephiumHome = "/alephium-home"
 

--- a/docker/user-testnet.conf
+++ b/docker/user-testnet.conf
@@ -1,5 +1,5 @@
 alephium.network.network-type = "testnet"
-alephium.discovery.bootstrap = ["18.221.19.228:9973", "3.142.153.145:9973"]
+alephium.discovery.bootstrap = ["3.68.2.201:9973", "34.236.121.90:9973", "54.252.31.241:9973"]
 alephium.mining.miner-addresses = ["T151XWPo8AzfK14TWux2JMV5NKkStLhkXqqcYZNy8hoM6J","T19Fb9yrYbKLFke12cjNiQYRo9SErS3wyCz68abaS4Kumy","T1C8b4fUbojXEZMnvDZZdcCts3FXkHyhFTLb22s88EnHxs","T1ZL4ZX8FL55VRcqsJaR9QwPwy5AUtMVxKvgUzwRprr8Q"]
 
 alephium.api.network-interface = "0.0.0.0"


### PR DESCRIPTION
This PR adds user.conf for testnet inside the containers.
It also refactor a little bit the Dockerfile to follow the best practices, mostly: group RUN statement to limit layers, reorder to facilitate caching, prefer COPY over ADD.