### PR TITLE
Remove all global execution context

### DIFF
--- a/app/src/main/scala/org/alephium/app/Boot.scala
+++ b/app/src/main/scala/org/alephium/app/Boot.scala
@@ -56,9 +56,7 @@ class BootUp extends StrictLogging {
   implicit val apiConfig: ApiConfig   = ApiConfig.load(typesafeConfig, "alephium.api")
   val flowSystem: ActorSystem         = ActorSystem("flow", typesafeConfig)
 
-  @SuppressWarnings(Array("org.wartremover.warts.GlobalExecutionContext"))
-  implicit val executionContext: ExecutionContext =
-    scala.concurrent.ExecutionContext.Implicits.global
+  implicit val executionContext: ExecutionContext = flowSystem.dispatcher
 
   val server: Server = Server(rootPath, flowSystem)
 

--- a/app/src/test/scala/org/alephium/app/RestServerSpec.scala
+++ b/app/src/test/scala/org/alephium/app/RestServerSpec.scala
@@ -864,7 +864,7 @@ trait RestServerFixture extends ServerFixture with HttpRouteFixture with SocketU
       )(
         serverConfig.broker,
         peerConf,
-        scala.concurrent.ExecutionContext.Implicits.global
+        ExecutionContext.fromExecutorService(new java.util.concurrent.ForkJoinPool)
       )
     })
   }

--- a/app/src/test/scala/org/alephium/app/ServerFixture.scala
+++ b/app/src/test/scala/org/alephium/app/ServerFixture.scala
@@ -169,7 +169,7 @@ object ServerFixture {
   )(implicit val config: AlephiumConfig)
       extends Node {
     implicit val system: ActorSystem       = ActorSystem("NodeDummy")
-    val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+    val executionContext: ExecutionContext = system.dispatcher
     val blockFlow: BlockFlow               = new BlockFlowDummy(block, blockFlowProbe, dummyTx, storages)
 
     val misbehaviorManager: ActorRefT[MisbehaviorManager.Command] =

--- a/app/src/test/scala/org/alephium/app/ServerSpec.scala
+++ b/app/src/test/scala/org/alephium/app/ServerSpec.scala
@@ -29,13 +29,12 @@ class ServerSpec extends AlephiumSpec with ScalaFutures {
   implicit override val patienceConfig = PatienceConfig(timeout = Span(1, Minutes))
 
   it should "start and stop correctly" in {
-    val rootPath                        = Platform.getRootPath()
-    val rawConfig                       = Configs.parseConfig(rootPath, overwrite = true)
-    implicit val config: AlephiumConfig = AlephiumConfig.load(rawConfig)
-    implicit val apiConfig: ApiConfig   = ApiConfig.load(rawConfig)
-    val flowSystem: ActorSystem         = ActorSystem("flow", rawConfig)
-    implicit val executionContext: ExecutionContext =
-      scala.concurrent.ExecutionContext.Implicits.global
+    val rootPath                                    = Platform.getRootPath()
+    val rawConfig                                   = Configs.parseConfig(rootPath, overwrite = true)
+    implicit val config: AlephiumConfig             = AlephiumConfig.load(rawConfig)
+    implicit val apiConfig: ApiConfig               = ApiConfig.load(rawConfig)
+    val flowSystem: ActorSystem                     = ActorSystem("flow", rawConfig)
+    implicit val executionContext: ExecutionContext = flowSystem.dispatcher
 
     val server = Server(rootPath, flowSystem)
 

--- a/app/src/test/scala/org/alephium/app/ServerUtilsSpec.scala
+++ b/app/src/test/scala/org/alephium/app/ServerUtilsSpec.scala
@@ -16,6 +16,8 @@
 
 package org.alephium.app
 
+import scala.concurrent.ExecutionContext
+
 import org.alephium.api.model._
 import org.alephium.flow.FlowFixture
 import org.alephium.flow.core.BlockFlow
@@ -27,7 +29,8 @@ import org.alephium.protocol.vm.GasBox
 import org.alephium.util.{AlephiumSpec, AVector, TimeStamp, U256}
 
 class ServerUtilsSpec extends AlephiumSpec {
-  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+  implicit val executionContext: ExecutionContext =
+    ExecutionContext.fromExecutorService(new java.util.concurrent.ForkJoinPool)
 
   trait Fixture extends FlowFixture {
     implicit def flowImplicit: BlockFlow = blockFlow

--- a/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
+++ b/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
@@ -23,7 +23,6 @@ import org.alephium.protocol.config.GroupConfig
 import org.alephium.util.Duration
 import org.alephium.wallet.WalletDocumentation
 
-@SuppressWarnings(Array("org.wartremover.warts.GlobalExecutionContext"))
 object OpenApiUpdate extends App {
 
   val wallet: WalletDocumentation = new WalletDocumentation {

--- a/util/src/test/scala/org/alephium/util/ServiceSpec.scala
+++ b/util/src/test/scala/org/alephium/util/ServiceSpec.scala
@@ -18,11 +18,11 @@ package org.alephium.util
 
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.ExecutionContext.Implicits
 
 class ServiceSpec extends AlephiumFutureSpec {
   trait Test extends Service {
-    implicit override protected def executionContext: ExecutionContext = Implicits.global
+    implicit override protected def executionContext: ExecutionContext =
+      ExecutionContext.fromExecutorService(new java.util.concurrent.ForkJoinPool)
 
     var startNum: Int = 0
     var stopNum: Int  = 0

--- a/wallet/src/main/scala/org/alephium/wallet/WalletRunner.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/WalletRunner.scala
@@ -28,9 +28,8 @@ import org.alephium.util.{Duration, Service}
 import org.alephium.wallet.config.WalletConfig
 
 object Main extends App with Service with StrictLogging {
-  @SuppressWarnings(Array("org.wartremover.warts.GlobalExecutionContext"))
   implicit val executionContext: ExecutionContext =
-    scala.concurrent.ExecutionContext.Implicits.global
+    ExecutionContext.fromExecutorService(new java.util.concurrent.ForkJoinPool)
 
   val typesafeConfig: Config = ConfigFactory.load()
 

--- a/wallet/src/test/scala/org/alephium/wallet/WalletAppSpec.scala
+++ b/wallet/src/test/scala/org/alephium/wallet/WalletAppSpec.scala
@@ -18,6 +18,8 @@ package org.alephium.wallet
 
 import java.net.InetAddress
 
+import scala.concurrent.ExecutionContext
+
 import io.vertx.core.Vertx
 import io.vertx.ext.web._
 import io.vertx.ext.web.handler.BodyHandler
@@ -48,7 +50,8 @@ class WalletAppSpec
     with HttpRouteFixture
     with IntegrationPatience {
 
-  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+  implicit val ec: ExecutionContext =
+    ExecutionContext.fromExecutorService(new java.util.concurrent.ForkJoinPool)
 
   val blockFlowMock =
     new WalletAppSpec.BlockFlowServerMock(host, blockFlowPort)

--- a/wallet/src/test/scala/org/alephium/wallet/service/WalletServiceSpec.scala
+++ b/wallet/src/test/scala/org/alephium/wallet/service/WalletServiceSpec.scala
@@ -19,9 +19,8 @@ package org.alephium.wallet.service
 import java.io.File
 import java.nio.file.Paths
 
+import scala.concurrent.ExecutionContext
 import scala.util.Random
-
-import akka.actor.ActorSystem
 
 import org.alephium.api.model.Destination
 import org.alephium.crypto.wallet.Mnemonic
@@ -198,9 +197,8 @@ class WalletServiceSpec extends AlephiumFutureSpec {
   trait Fixture extends WalletConfigFixture {
     val password     = "password"
     val mnemonicSize = Mnemonic.Size(12).get
-    implicit val system: ActorSystem =
-      ActorSystem(s"wallet-service-spec-${Random.nextInt()}")
-    implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+    implicit val executionContext: ExecutionContext =
+      ExecutionContext.fromExecutorService(new java.util.concurrent.ForkJoinPool)
     lazy val blockFlowClient =
       BlockFlowClient.apply(
         config.blockflow.uri,


### PR DESCRIPTION
Using the actor system dispatcher when one is in scope, otherwise:

```
ExecutionContext.fromExecutorService(new java.util.concurrent.ForkJoinPool)
```