### PR TITLE
Add target hash rate metric

### DIFF
--- a/docker/grafana/provisioning/dashboards/alephium-overview.json
+++ b/docker/grafana/provisioning/dashboards/alephium-overview.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 11,
-  "iteration": 1622658390071,
+  "iteration": 1631822972612,
   "links": [],
   "panels": [
     {
@@ -3092,6 +3092,103 @@
         {
           "$$hashKey": "object:109",
           "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Target Hash Rate Per Chain",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 142
+      },
+      "hiddenSeries": false,
+      "id": 77,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.10",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "alephium_target_hash_rate_hertz{app=\"alephium\"}",
+          "interval": "",
+          "legendFormat": "Chain ({{chain_from}}, {{chain_to}})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Target Hash Rate Per Chain",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:181",
+          "format": "Hs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:182",
           "format": "short",
           "label": null,
           "logBase": 1,

--- a/flow/src/main/scala/org/alephium/flow/handler/ChainHandler.scala
+++ b/flow/src/main/scala/org/alephium/flow/handler/ChainHandler.scala
@@ -23,6 +23,7 @@ import org.alephium.flow.model.DataOrigin
 import org.alephium.flow.validation._
 import org.alephium.io.{IOError, IOResult}
 import org.alephium.protocol.config.ConsensusConfig
+import org.alephium.protocol.mining.HashRate
 import org.alephium.protocol.model.{BlockHeader, ChainIndex, FlowData}
 import org.alephium.serde.{serialize, Serde}
 import org.alephium.util._
@@ -76,6 +77,14 @@ object ChainHandler {
     .build(
       "alephium_block_current_height",
       "Current height of the block"
+    )
+    .labelNames("chain_from", "chain_to")
+    .register()
+
+  val targetHashRateHertz: Gauge = Gauge
+    .build(
+      "alephium_target_hash_rate_hertz",
+      "Target hash rate"
     )
     .labelNames("chain_from", "chain_to")
     .register()
@@ -202,6 +211,9 @@ abstract class ChainHandler[T <: FlowData: Serde, S <: InvalidStatus, V <: Valid
       }
     }
 
+    val hashRate = HashRate.from(header.target, consensusConfig.blockTargetTime)
+    targetHashRateHertzLabeled.set(hashRate.value.doubleValue)
+
     chain
   }
 
@@ -212,5 +224,8 @@ abstract class ChainHandler[T <: FlowData: Serde, S <: InvalidStatus, V <: Valid
     .labels(chainIndexFromString, chainIndexToString)
 
   private val blockCurrentHeightLabeled = blockCurrentHeight
+    .labels(chainIndexFromString, chainIndexToString)
+
+  private val targetHashRateHertzLabeled = targetHashRateHertz
     .labels(chainIndexFromString, chainIndexToString)
 }


### PR DESCRIPTION
Fixes #333.

This adds a gauge metric that reports the target hash rate for each chain.

Example data from testnet:

![Screenshot of Grafana graph showing testnet target hash rate metric over time.](https://user-images.githubusercontent.com/50083900/133678058-0b2f6044-a81b-4523-a1ce-c119893d5058.png)
