### PR TITLE
Use `U256` for token amount instead of `Amount`

### DIFF
--- a/api/src/main/scala/org/alephium/api/EndpointsExamples.scala
+++ b/api/src/main/scala/org/alephium/api/EndpointsExamples.scala
@@ -72,8 +72,8 @@ trait EndpointsExamples extends ErrorExamples {
   val txId =
     Hash.from(Hex.unsafe("503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69")).get
   private val tokens = AVector(
-    Token(Hash.hash("token1"), alf(42)),
-    Token(Hash.hash("token2"), alf(1000))
+    Token(Hash.hash("token1"), alf(42).value),
+    Token(Hash.hash("token2"), alf(1000).value)
   )
   val defaultDestinations = AVector(Destination(address, twoAlf, None, None))
   val moreSettingsDestinations = AVector(

--- a/api/src/main/scala/org/alephium/api/model/Output.scala
+++ b/api/src/main/scala/org/alephium/api/model/Output.scala
@@ -52,7 +52,7 @@ object Output {
         Asset(
           Amount(o.amount),
           Address.Asset(o.lockupScript),
-          o.tokens.map((Token.from).tupled),
+          o.tokens.map(Token.tupled),
           o.lockTime,
           o.additionalData
         )
@@ -60,7 +60,7 @@ object Output {
         Contract(
           Amount(o.amount),
           Address.Contract(o.lockupScript),
-          o.tokens.map((Token.from).tupled)
+          o.tokens.map(Token.tupled)
         )
     }
   }

--- a/api/src/main/scala/org/alephium/api/model/Token.scala
+++ b/api/src/main/scala/org/alephium/api/model/Token.scala
@@ -19,8 +19,4 @@ package org.alephium.api.model
 import org.alephium.protocol.Hash
 import org.alephium.util.U256
 
-final case class Token(id: Hash, amount: Amount)
-
-object Token {
-  def from(id: Hash, amount: U256): Token = Token(id, Amount(amount))
-}
+final case class Token(id: Hash, amount: U256)

--- a/api/src/main/scala/org/alephium/api/model/UTXO.scala
+++ b/api/src/main/scala/org/alephium/api/model/UTXO.scala
@@ -37,7 +37,7 @@ object UTXO {
     UTXO(
       OutputRef.from(ref),
       Amount(amount),
-      tokens.map((Token.from).tupled),
+      tokens.map(Token.tupled),
       lockTime,
       additionalData
     )

--- a/api/src/test/scala/org/alephium/api/ApiModelSpec.scala
+++ b/api/src/test/scala/org/alephium/api/ApiModelSpec.scala
@@ -202,6 +202,19 @@ class ApiModelSpec extends AlephiumSpec with ApiModelCodec with EitherValues wit
     }
   }
 
+  it should "encode/decode Token" in {
+    val id     = Hash.generate
+    val amount = ALF.oneAlf
+
+    val token: Token = Token(id, amount)
+    val jsonRaw =
+      s"""{"id":"${id.toHexString}","amount":"${amount}"}"""
+
+    checkData(token, jsonRaw)
+
+    parseFail[Token](s"""{"id":"${id.toHexString}","amount":"1 ALPH"}""")
+  }
+
   it should "encode/decode Output with big amount" in {
     val address    = generateAddress()
     val addressStr = address.toBase58

--- a/api/src/test/scala/org/alephium/api/ApiModelSpec.scala
+++ b/api/src/test/scala/org/alephium/api/ApiModelSpec.scala
@@ -210,7 +210,7 @@ class ApiModelSpec extends AlephiumSpec with ApiModelCodec with EitherValues wit
     val tokenId1   = Hash.hash("token1")
     val tokenId2   = Hash.hash("token2")
     val tokens =
-      AVector(Token(tokenId1, Amount(U256.unsafe(42))), Token(tokenId2, Amount(U256.unsafe(1000))))
+      AVector(Token(tokenId1, U256.unsafe(42)), Token(tokenId2, U256.unsafe(1000)))
 
     {
       val request: Output = Output.Contract(amount, address, tokens)
@@ -345,7 +345,7 @@ class ApiModelSpec extends AlephiumSpec with ApiModelCodec with EitherValues wit
           Destination(
             toAddress,
             Amount(1),
-            Some(AVector(Token(tokenId1, Amount(U256.Ten)))),
+            Some(AVector(Token(tokenId1, U256.Ten))),
             Some(TimeStamp.unsafe(1234))
           )
         ),
@@ -385,7 +385,7 @@ class ApiModelSpec extends AlephiumSpec with ApiModelCodec with EitherValues wit
           Destination(
             toAddress,
             Amount(1),
-            Some(AVector(Token(tokenId1, Amount(U256.Ten)))),
+            Some(AVector(Token(tokenId1, U256.Ten))),
             Some(TimeStamp.unsafe(1234))
           )
         ),
@@ -426,7 +426,7 @@ class ApiModelSpec extends AlephiumSpec with ApiModelCodec with EitherValues wit
           Destination(
             toAddress,
             Amount(1),
-            Some(AVector(Token(tokenId1, Amount(U256.Ten)))),
+            Some(AVector(Token(tokenId1, U256.Ten))),
             Some(TimeStamp.unsafe(1234))
           )
         ),

--- a/app/src/main/scala/org/alephium/app/ServerUtils.scala
+++ b/app/src/main/scala/org/alephium/app/ServerUtils.scala
@@ -371,7 +371,7 @@ class ServerUtils(implicit
       val tokensInfo = destination.tokens match {
         case Some(tokens) =>
           tokens.map { token =>
-            (token.id -> token.amount.value)
+            (token.id -> token.amount)
           }
         case None =>
           AVector.empty[(TokenId, U256)]

--- a/app/src/test/scala/org/alephium/app/ServerUtilsSpec.scala
+++ b/app/src/test/scala/org/alephium/app/ServerUtilsSpec.scala
@@ -590,7 +590,7 @@ class ServerUtilsSpec extends AlephiumSpec {
   ): Destination = {
     val address = generateAddress(chainIndex)
     val amount  = Amount(ALF.oneAlf)
-    Destination(address, amount, Some(AVector.from(tokens).map(Token.from.tupled)))
+    Destination(address, amount, Some(AVector.from(tokens).map(Token.apply.tupled)))
   }
 
   private def generateAddress(chainIndex: ChainIndex)(implicit

--- a/build.sbt
+++ b/build.sbt
@@ -327,7 +327,7 @@ val publishSettings = Seq(
 )
 
 val commonSettings = publishSettings ++ Seq(
-  scalaVersion := "2.13.5",
+  scalaVersion := "2.13.6",
   parallelExecution in Test := false,
   scalacOptions ++= Seq(
 //    "-Xdisable-assertions", // TODO: use this properly


### PR DESCRIPTION
`Amount` is using the `1.234 ALPH` format, while a token usually have
its own extension.