### PR TITLE
Add `/utils/verify` endpoint

### DIFF
--- a/api/src/main/resources/openapi.json
+++ b/api/src/main/resources/openapi.json
@@ -5185,6 +5185,108 @@
         }
       }
     },
+    "/utils/verify-signature": {
+      "post": {
+        "tags": [
+          "Utils"
+        ],
+        "summary": "Verify the SecP256K1 signature of some data",
+        "operationId": "postUtilsVerify-signature",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifySignature"
+              },
+              "example": {
+                "data": "0ecd20654c2e2be708495853e8da35c664247040c00bd10b9b13",
+                "signature": "9e1a35b2931bd04e6780d01c36e3e5337941aa80f173cfe4f4e249c44ab135272b834c1a639db9c89d673a8a30524042b0469672ca845458a5a0cf2cad53221b",
+                "publicKey": "d1b70d2226308b46da297486adb6b4f1a8c1842cb159ac5ec04f384fe2d6f5da28"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                },
+                "example": true
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/miners": {
       "post": {
         "tags": [
@@ -6817,6 +6919,25 @@
             "items": {
               "$ref": "#/components/schemas/Tx"
             }
+          }
+        }
+      },
+      "VerifySignature": {
+        "required": [
+          "data",
+          "signature",
+          "publicKey"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          },
+          "publicKey": {
+            "type": "string"
           }
         }
       },

--- a/api/src/main/scala/org/alephium/api/ApiModel.scala
+++ b/api/src/main/scala/org/alephium/api/ApiModel.scala
@@ -305,6 +305,8 @@ trait ApiModelCodec {
     }
   }
 
+  implicit val verifySignatureRW: RW[VerifySignature] = macroRW
+
   private def bytesWriter[T <: RandomBytes]: Writer[T] =
     StringWriter.comap[T](_.toHexString)
 

--- a/api/src/main/scala/org/alephium/api/Endpoints.scala
+++ b/api/src/main/scala/org/alephium/api/Endpoints.scala
@@ -100,6 +100,11 @@ trait Endpoints
       .in("blockflow")
       .tag("Blockflow")
 
+  private val utilsEndpoint: BaseEndpoint[Unit, Unit] =
+    baseEndpoint
+      .in("utils")
+      .tag("Utils")
+
   val getNodeInfo: BaseEndpoint[Unit, NodeInfo] =
     infosEndpoint.get
       .in("node")
@@ -327,6 +332,13 @@ trait Endpoints
       .in(path[BlockHash]("block_hash"))
       .out(jsonBody[BlockHeaderEntry])
       .summary("Get block header")
+
+  val verifySignature: BaseEndpoint[VerifySignature, Boolean] =
+    utilsEndpoint.post
+      .in("verify-signature")
+      .in(jsonBody[VerifySignature])
+      .out(jsonBody[Boolean])
+      .summary("Verify the SecP256K1 signature of some data")
 }
 
 object Endpoints {

--- a/api/src/main/scala/org/alephium/api/EndpointsExamples.scala
+++ b/api/src/main/scala/org/alephium/api/EndpointsExamples.scala
@@ -408,5 +408,8 @@ trait EndpointsExamples extends ErrorExamples {
 
   implicit val booleanExamples: List[Example[Boolean]] =
     simpleExample(true)
+
+  implicit val verifySignatureExamples: List[Example[VerifySignature]] =
+    simpleExample(VerifySignature(Hex.unsafe(hexString), signature, publicKey))
 }
 // scalastyle:on magic.number

--- a/api/src/main/scala/org/alephium/api/model/VerifySignature.scala
+++ b/api/src/main/scala/org/alephium/api/model/VerifySignature.scala
@@ -1,0 +1,27 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.api.model
+
+import akka.util.ByteString
+
+import org.alephium.protocol.{PublicKey, Signature}
+
+final case class VerifySignature(
+    data: ByteString,
+    signature: Signature,
+    publicKey: PublicKey
+)

--- a/api/src/test/scala/org/alephium/api/ApiModelSpec.scala
+++ b/api/src/test/scala/org/alephium/api/ApiModelSpec.scala
@@ -680,4 +680,21 @@ class ApiModelSpec extends AlephiumSpec with ApiModelCodec with EitherValues wit
          |""".stripMargin
     checkData(buildScriptResult, jsonRaw)
   }
+
+  it should "encode/decode VerifySignature" in {
+    val data      = Hash.generate.bytes
+    val publicKey = PublicKey.generate
+    val signature = Signature.generate
+
+    val verifySignature =
+      VerifySignature(data, signature, publicKey)
+    val jsonRaw = s"""
+        |{
+        |  "data": "${Hex.toHexString(data)}",
+        |  "signature": "${signature.toHexString}",
+        |  "publicKey": "${publicKey.toHexString}"
+        |}
+        """.stripMargin
+    checkData(verifySignature, jsonRaw)
+  }
 }

--- a/app/src/it/scala/org/alephium/app/CliqueFixture.scala
+++ b/app/src/it/scala/org/alephium/app/CliqueFixture.scala
@@ -449,6 +449,15 @@ class CliqueFixture(implicit spec: AlephiumActorSpec)
     )
   }
 
+  def verify(data: String, signature: Signature, publicKey: String) = {
+    httpPost(
+      s"/utils/verify-signature",
+      Some(
+        s"""{"data":"$data","signature":"${signature.toHexString}","publicKey":"${publicKey}"}"""
+      )
+    )
+  }
+
   def submitTransaction(buildTransactionResult: BuildTransactionResult, privateKey: String) = {
     val signature: Signature = SignatureSchema.sign(
       buildTransactionResult.txId.bytes,

--- a/app/src/it/scala/org/alephium/app/MultisigTest.scala
+++ b/app/src/it/scala/org/alephium/app/MultisigTest.scala
@@ -20,7 +20,7 @@ import org.alephium.api.ApiError
 import org.alephium.api.model._
 import org.alephium.flow.validation.{InvalidSignature, NotEnoughSignature}
 import org.alephium.json.Json._
-import org.alephium.protocol.{PrivateKey, Signature, SignatureSchema}
+import org.alephium.protocol.{Hash, PrivateKey, Signature, SignatureSchema}
 import org.alephium.protocol.model._
 import org.alephium.serde.{deserialize, serialize}
 import org.alephium.util._
@@ -167,6 +167,26 @@ class MultisigTest extends AlephiumActorSpec {
 
     val signature2: Signature =
       request[Sign.Result](sign(walletName, buildTxResult.txId.toHexString), restPort).signature
+
+    request[Boolean](
+      verify(buildTxResult.txId.toHexString, signature1, publicKey),
+      restPort
+    ) is true
+
+    request[Boolean](
+      verify(buildTxResult.txId.toHexString, signature2, publicKey2),
+      restPort
+    ) is true
+
+    request[Boolean](
+      verify(buildTxResult.txId.toHexString, signature2, publicKey),
+      restPort
+    ) is false
+
+    request[Boolean](
+      verify(Hash.generate.toHexString, signature1, publicKey),
+      restPort
+    ) is false
 
     val submitMultisigTx =
       submitMultisigTransaction(buildTxResult, AVector(signature1, signature2))

--- a/app/src/main/scala/org/alephium/app/Documentation.scala
+++ b/app/src/main/scala/org/alephium/app/Documentation.scala
@@ -55,6 +55,7 @@ trait Documentation extends Endpoints with OpenAPIDocsInterpreter {
     buildMultisigAddress,
     buildMultisig,
     submitMultisigTransaction,
+    verifySignature,
     minerAction,
     minerListAddresses,
     minerUpdateAddresses

--- a/app/src/main/scala/org/alephium/app/EndpointsLogic.scala
+++ b/app/src/main/scala/org/alephium/app/EndpointsLogic.scala
@@ -443,6 +443,10 @@ trait EndpointsLogic extends Endpoints with EndpointSender with SttpClientInterp
     serverUtils.buildContract(blockFlow, query)
   }
 
+  val verifySignatureLogic = serverLogic(verifySignature) { query =>
+    Future.successful(serverUtils.verifySignature(query))
+  }
+
   val exportBlocksLogic = serverLogic(exportBlocks) { exportFile =>
     //Run the export in background
     Future.successful(

--- a/app/src/main/scala/org/alephium/app/RestServer.scala
+++ b/app/src/main/scala/org/alephium/app/RestServer.scala
@@ -95,6 +95,7 @@ class RestServer(
       compileContractLogic,
       buildContractLogic,
       exportBlocksLogic,
+      verifySignatureLogic,
       metricsLogic
     ).map(route(_)) :+ swaggerUiRoute
 

--- a/app/src/main/scala/org/alephium/app/ServerUtils.scala
+++ b/app/src/main/scala/org/alephium/app/ServerUtils.scala
@@ -27,7 +27,7 @@ import org.alephium.api.model._
 import org.alephium.flow.core.{BlockFlow, BlockFlowState}
 import org.alephium.flow.handler.TxHandler
 import org.alephium.io.IOError
-import org.alephium.protocol.{BlockHash, Hash, PublicKey, Signature}
+import org.alephium.protocol.{BlockHash, Hash, PublicKey, Signature, SignatureSchema}
 import org.alephium.protocol.config.{BrokerConfig, NetworkConfig}
 import org.alephium.protocol.model._
 import org.alephium.protocol.model.UnsignedTransaction.TxOutputInfo
@@ -605,6 +605,10 @@ class ServerUtils(implicit
         query.gasPrice
       ).left.map(error => badRequest(error.toString))
     } yield utx).map(BuildContractResult.from))
+  }
+
+  def verifySignature(query: VerifySignature): Try[Boolean] = {
+    Right(SignatureSchema.verify(query.data, query.signature, query.publicKey))
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))


### PR DESCRIPTION
Used to check if some data is correctly signed.

Based on: https://developer.bitcoin.org/reference/rpc/verifymessage.html