### PR TITLE
Make console log level configurable

### DIFF
--- a/flow/src/main/resources/logback.xml
+++ b/flow/src/main/resources/logback.xml
@@ -37,7 +37,7 @@
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
+            <level>${ALEPHIUM_LOG_LEVEL:-INFO}</level>
         </filter>
 
         <encoder>


### PR DESCRIPTION
Introduce the `ALEPHIUM_LOG_LEVEL` environment variable to make console log configurable. 
Console log is what gets picked up by many cloud provider for cloud logging. For example in GCP console logs gets sent to Stackdriver and enabling INFO level in full node roughly costs 60 euros a month. 