### PR TITLE
Apply More Constrains on UTXO Endpoints

### DIFF
--- a/app/src/test/scala/org/alephium/app/ServerUtilsSpec.scala
+++ b/app/src/test/scala/org/alephium/app/ServerUtilsSpec.scala
@@ -616,10 +616,28 @@ class ServerUtilsSpec extends AlephiumSpec {
         outputRefsOpt = Some(outputRefs),
         destinations,
         gasOpt = Some(minimalGas),
-        GasPrice(ALF.MaxALFValue)
+        GasPrice(ALPH.MaxALPHValue)
       )
       .leftValue
       .detail is "Gas price GasPrice(1000000000000000000000000000) too large, maximal GasPrice(999999999999999999999999999)"
+  }
+
+  it should "not create transaction when with amount overflow" in new MultipleUtxos {
+    val amountOverflowDestinations = AVector(
+      destination1,
+      destination2.copy(amount = Amount(ALPH.MaxALPHValue))
+    )
+    serverUtils
+      .prepareUnsignedTransaction(
+        blockFlow,
+        fromPublicKey,
+        outputRefsOpt = None,
+        amountOverflowDestinations,
+        gasOpt = Some(minimalGas),
+        GasPrice(minimalGasPrice.value - 1)
+      )
+      .leftValue
+      .detail is "ALPH Amount overflow"
   }
 
   it should "not create transaction when not all utxos are of asset type" in new MultipleUtxos {
@@ -658,7 +676,7 @@ class ServerUtilsSpec extends AlephiumSpec {
       .detail is "Zero transaction outputs"
 
     info("Too many outputs")
-    val tooManyDestinations = AVector.fill(ALF.MaxTxOutputNum + 1)(generateDestination(chainIndex))
+    val tooManyDestinations = AVector.fill(ALPH.MaxTxOutputNum + 1)(generateDestination(chainIndex))
     serverUtils
       .buildTransaction(
         blockFlow,

--- a/app/src/test/scala/org/alephium/app/ServerUtilsSpec.scala
+++ b/app/src/test/scala/org/alephium/app/ServerUtilsSpec.scala
@@ -623,7 +623,7 @@ class ServerUtilsSpec extends AlephiumSpec {
       .detail is "Gas price GasPrice(1000000000000000000000000000) too large, maximal GasPrice(999999999999999999999999999)"
   }
 
-  it should "not create transaction when with ALPH amount overflow" in new MultipleUtxos {
+  it should "not create transaction with overflowing ALPH amount" in new MultipleUtxos {
     val alphAmountOverflowDestinations = AVector(
       destination1,
       destination2.copy(amount = Amount(ALPH.MaxALPHValue))
@@ -638,7 +638,7 @@ class ServerUtilsSpec extends AlephiumSpec {
         defaultGasPrice
       )
       .leftValue
-      .detail is "ALPH Amount overflow"
+      .detail is "ALPH amount overflow"
   }
 
   it should "not create transaction when with token amount overflow" in new MultipleUtxos {

--- a/flow/src/main/scala/org/alephium/flow/core/TxUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/TxUtils.scala
@@ -131,8 +131,8 @@ trait TxUtils { Self: FlowUtils =>
   ): IOResult[Either[String, UnsignedTransaction]] = {
     val totalAmountsE = for {
       _               <- checkOutputInfos(outputInfos)
-      totalAlphAmount <- checkTotalAlphAmount(outputInfos.map(_.alphAmount))
       _               <- checkGas(gasOpt, gasPrice)
+      totalAlphAmount <- checkTotalAlphAmount(outputInfos.map(_.alphAmount))
       totalAmountPerToken <- UnsignedTransaction.calculateTotalAmountPerToken(
         outputInfos.flatMap(_.tokens)
       )
@@ -186,8 +186,11 @@ trait TxUtils { Self: FlowUtils =>
       val checkResult = for {
         _ <- checkUTXOsInSameGroup(utxoRefs)
         _ <- checkOutputInfos(outputInfos)
-        _ <- checkTotalAlphAmount(outputInfos.map(_.alphAmount))
         _ <- checkGas(gasOpt, gasPrice)
+        _ <- checkTotalAlphAmount(outputInfos.map(_.alphAmount))
+        _ <- UnsignedTransaction.calculateTotalAmountPerToken(
+          outputInfos.flatMap(_.tokens)
+        )
       } yield ()
 
       checkResult match {

--- a/flow/src/main/scala/org/alephium/flow/core/TxUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/TxUtils.scala
@@ -263,6 +263,8 @@ trait TxUtils { Self: FlowUtils =>
     }
   }
 
+  // TODO: Here if we have too many tokens in the output, we could split it into multiple
+  //       outputs
   def buildSweepAllTxOutputsWithGas(
       toLockupScript: LockupScript.Asset,
       lockTimeOpt: Option[TimeStamp],
@@ -385,7 +387,7 @@ trait TxUtils { Self: FlowUtils =>
     amounts.foldE(U256.Zero) { case (acc, amount) =>
       acc.add(amount).toRight("Alph Amount overflow").flatMap { newAmount =>
         if (newAmount > ALPH.MaxALPHValue) {
-          Left("ALPH Amount overflow")
+          Left("ALPH amount overflow")
         } else {
           Right(newAmount)
         }

--- a/flow/src/main/scala/org/alephium/flow/core/UtxoUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/UtxoUtils.scala
@@ -210,8 +210,8 @@ object UtxoUtils {
       } yield result
 
       foundResult match {
-        case Right((_, foundUtxos, otherUtxos)) =>
-          findUtxosForTokens(currentUtxos ++ foundUtxos, otherUtxos, totalAmountPerToken.tail)
+        case Right((_, foundUtxos, remainingUtxos)) =>
+          findUtxosForTokens(currentUtxos ++ foundUtxos, remainingUtxos, totalAmountPerToken.tail)
         case Left(e) =>
           Left(e)
       }

--- a/flow/src/main/scala/org/alephium/flow/core/UtxoUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/UtxoUtils.scala
@@ -143,11 +143,11 @@ object UtxoUtils {
     estimateGas(defaultGasPerInput, defaultGasPerOutput, numInputs, numOutputs, minimalGas)
   }
 
-  def estimateSweepAllTxGas(numInputs: Int): GasBox = {
+  def estimateSweepAllTxGas(numInputs: Int, numOutputs: Int): GasBox = {
+    val outputGas = GasSchedule.txOutputBaseGas.addUnsafe(GasSchedule.p2pkUnlockGas)
     val gas = GasSchedule.txBaseGas
       .addUnsafe(GasSchedule.txInputBaseGas.mulUnsafe(numInputs))
-      .addUnsafe(GasSchedule.txOutputBaseGas)
-      .addUnsafe(GasSchedule.p2pkUnlockGas)
+      .addUnsafe(outputGas.mulUnsafe(numOutputs))
     Math.max(gas, minimalGas)
   }
 

--- a/flow/src/test/scala/org/alephium/flow/core/TxUtilsSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/core/TxUtilsSpec.scala
@@ -543,7 +543,7 @@ class TxUtilsSpec extends AlephiumSpec {
         defaultUtxoLimit
       )
       .rightValue
-      .leftValue is s"Too many inputs for the transfer, consider to reduce the amount to send"
+      .leftValue is "Too many inputs for the transfer, consider to reduce the amount to send, or use the `sweep-all` endpoint to consolidate the inputs first"
   }
 
   it should "sweep as much as we can" in new LargeUtxos {

--- a/protocol/src/main/scala/org/alephium/protocol/model/UnsignedTransaction.scala
+++ b/protocol/src/main/scala/org/alephium/protocol/model/UnsignedTransaction.scala
@@ -149,7 +149,10 @@ object UnsignedTransaction {
     val gasFee = gasPrice * gas
     for {
       _               <- checkWithMaxTxInputNum(inputs)
+      _               <- checkUniqueInputs(inputs)
       _               <- checkMinimalAlphPerOutput(outputs)
+      _               <- checkMaximumTokenNumPerOutput(outputs)
+      _               <- checkTokenValuesNonZero(outputs)
       alphRemainder   <- calculateAlphRemainder(inputs, outputs, gasFee)
       tokensRemainder <- calculateTokensRemainder(inputs, outputs)
       changeOutputOpt <- calculateChangeOutput(alphRemainder, tokensRemainder, fromLockupScript)
@@ -177,14 +180,22 @@ object UnsignedTransaction {
     }
   }
 
+  def checkUniqueInputs(
+      assets: AVector[(AssetOutputRef, AssetOutput)]
+  ): Either[String, Unit] = {
+    check(
+      failCondition = assets.length > assets.map(_._1).toSet.size,
+      "Inputs not unique"
+    )
+  }
+
   def checkWithMaxTxInputNum(
       assets: AVector[(AssetOutputRef, AssetOutput)]
   ): Either[String, Unit] = {
-    if (assets.length > ALPH.MaxTxInputNum) {
-      Left(s"Too many inputs for the transfer, consider to reduce the amount to send")
-    } else {
-      Right(())
-    }
+    check(
+      failCondition = assets.length > ALPH.MaxTxInputNum,
+      "Too many inputs for the transfer, consider to reduce the amount to send, or use the `sweep-all` endpoint to consolidate the inputs first"
+    )
   }
 
   def calculateAlphRemainder(
@@ -214,6 +225,8 @@ object UnsignedTransaction {
     }
   }
 
+  // TODO: Here if we have too many tokens in the change output, we could split it into
+  //       several change outputs so that the built transaction can still be valid
   def calculateChangeOutput(
       alphRemainder: U256,
       tokensRemainder: AVector[(TokenId, U256)],
@@ -221,6 +234,8 @@ object UnsignedTransaction {
   ): Either[String, Option[AssetOutput]] = {
     if (alphRemainder == U256.Zero && tokensRemainder.isEmpty) {
       Right(None)
+    } else if (tokensRemainder.length > maxTokenPerUtxo) {
+      Left(s"Too many tokens in the transaction output, maximum number $maxTokenPerUtxo")
     } else {
       if (alphRemainder > minimalAlphAmountPerTxOutput(tokensRemainder.length)) {
         Right(Some(TxOutput.asset(alphRemainder, tokensRemainder, fromLockupScript)))
@@ -233,15 +248,30 @@ object UnsignedTransaction {
   private def checkMinimalAlphPerOutput(
       outputs: AVector[TxOutputInfo]
   ): Either[String, Unit] = {
-    val notOk = outputs.exists { output =>
-      output.alphAmount < minimalAlphAmountPerTxOutput(output.tokens.length)
-    }
+    check(
+      failCondition = outputs.exists { output =>
+        output.alphAmount < minimalAlphAmountPerTxOutput(output.tokens.length)
+      },
+      "Not enough Alph for transaction output"
+    )
+  }
 
-    if (notOk) {
-      Left("Not enough Alph for transaction output")
-    } else {
-      Right(())
-    }
+  private def checkMaximumTokenNumPerOutput(
+      outputs: AVector[TxOutputInfo]
+  ): Either[String, Unit] = {
+    check(
+      failCondition = outputs.exists(_.tokens.length > maxTokenPerUtxo),
+      s"Too many tokens in the transaction output, maximum number $maxTokenPerUtxo"
+    )
+  }
+
+  private def checkTokenValuesNonZero(
+      outputs: AVector[TxOutputInfo]
+  ): Either[String, Unit] = {
+    check(
+      failCondition = outputs.exists(_.tokens.exists(_._2.isZero)),
+      "Value is Zero for one or many tokens in the transaction output"
+    )
   }
 
   def calculateTotalAmountPerToken(
@@ -264,11 +294,10 @@ object UnsignedTransaction {
       outputs: AVector[(TokenId, U256)]
   ): Either[String, Unit] = {
     val newTokens = outputs.map(_._1).toSet -- inputs.map(_._1).toSet
-    if (newTokens.nonEmpty) {
-      Left(s"New tokens found in outputs: $newTokens")
-    } else {
-      Right(())
-    }
+    check(
+      failCondition = newTokens.nonEmpty,
+      s"New tokens found in outputs: $newTokens"
+    )
   }
 
   private def calculateRemainingTokens(
@@ -281,6 +310,14 @@ object UnsignedTransaction {
         remainder =>
           acc :+ (inputId -> remainder)
       }
+    }
+  }
+
+  private def check(failCondition: Boolean, errorMessage: String): Either[String, Unit] = {
+    if (failCondition) {
+      Left(errorMessage)
+    } else {
+      Right(())
     }
   }
 

--- a/protocol/src/main/scala/org/alephium/protocol/model/UnsignedTransaction.scala
+++ b/protocol/src/main/scala/org/alephium/protocol/model/UnsignedTransaction.scala
@@ -235,12 +235,12 @@ object UnsignedTransaction {
     if (alphRemainder == U256.Zero && tokensRemainder.isEmpty) {
       Right(None)
     } else if (tokensRemainder.length > maxTokenPerUtxo) {
-      Left(s"Too many tokens in the transaction output, maximum number $maxTokenPerUtxo")
+      Left(s"Too many tokens in the change output, maximal number $maxTokenPerUtxo")
     } else {
       if (alphRemainder > minimalAlphAmountPerTxOutput(tokensRemainder.length)) {
         Right(Some(TxOutput.asset(alphRemainder, tokensRemainder, fromLockupScript)))
       } else {
-        Left("Not enough Alph for change output")
+        Left("Not enough ALPH for change output")
       }
     }
   }
@@ -252,7 +252,7 @@ object UnsignedTransaction {
       failCondition = outputs.exists { output =>
         output.alphAmount < minimalAlphAmountPerTxOutput(output.tokens.length)
       },
-      "Not enough Alph for transaction output"
+      "Not enough ALPH for transaction output"
     )
   }
 
@@ -261,7 +261,7 @@ object UnsignedTransaction {
   ): Either[String, Unit] = {
     check(
       failCondition = outputs.exists(_.tokens.length > maxTokenPerUtxo),
-      s"Too many tokens in the transaction output, maximum number $maxTokenPerUtxo"
+      s"Too many tokens in the transaction output, maximal number $maxTokenPerUtxo"
     )
   }
 

--- a/protocol/src/main/scala/org/alephium/protocol/model/UnsignedTransaction.scala
+++ b/protocol/src/main/scala/org/alephium/protocol/model/UnsignedTransaction.scala
@@ -314,11 +314,7 @@ object UnsignedTransaction {
   }
 
   private def check(failCondition: Boolean, errorMessage: String): Either[String, Unit] = {
-    if (failCondition) {
-      Left(errorMessage)
-    } else {
-      Right(())
-    }
+    Either.cond(!failCondition, (), errorMessage)
   }
 
   final case class TxOutputInfo(

--- a/protocol/src/main/scala/org/alephium/protocol/model/UnsignedTransaction.scala
+++ b/protocol/src/main/scala/org/alephium/protocol/model/UnsignedTransaction.scala
@@ -313,7 +313,7 @@ object UnsignedTransaction {
     }
   }
 
-  private def check(failCondition: Boolean, errorMessage: String): Either[String, Unit] = {
+  @inline private def check(failCondition: Boolean, errorMessage: String): Either[String, Unit] = {
     Either.cond(!failCondition, (), errorMessage)
   }
 


### PR DESCRIPTION
1. Add more checks when we build transactions, e.g. gas amount and price, token constrains per tx output, input uniqueness, etc
2. For `sweepAll` endpoint, try to generate more outputs if the number of tokens exceed `maxTokenPerUtxo`.
