### PR TITLE
Fixed bug for #issue453

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
   lazy val bcprov          = "org.bouncycastle"            % "bcprov-jdk15on"  % "1.68"
   lazy val fastparse       = "com.lihaoyi"                %% "fastparse"       % "2.3.1"
   lazy val logback         = "ch.qos.logback"              % "logback-classic" % "1.2.3"
-  lazy val rocksdb         = "org.rocksdb"                 % "rocksdbjni"      % "5.18.4"
+  lazy val rocksdb         = "org.rocksdb"                 % "rocksdbjni"      % "6.26.1"
   lazy val `scala-logging` = "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.2"
   lazy val scalacheck      = "org.scalacheck"             %% "scalacheck"      % "1.15.3"  % Test
   lazy val scalatest       = "org.scalatest"              %% "scalatest"       % "3.2.6"   % Test


### PR DESCRIPTION
Update rocksdb version to 6.26.1 in order to fix rocksdb exception . detail issue #453 

- tested for  window10、linux、macos、linux  wsl of window10 

- if merge , other error may be introduced ,detail [#9279](https://github.com/facebook/rocksdb/issues/9279),this issue is hard to reproduce. so, please  consider whether to merge