### PR TITLE
"Runtime: nvidia" causing error

### DIFF
--- a/docker/docker-compose.gpu-miner.yml
+++ b/docker/docker-compose.gpu-miner.yml
@@ -6,7 +6,6 @@ services:
     depends_on:
       - alephium
     restart: unless-stopped
-    runtime: nvidia
     privileged: true
     command:
       - -a


### PR DESCRIPTION
When trying the command : docker-compose -f docker-compose.yml -f docker-compose.gpu-miner.yml up -d
It returns the following error :
Creating alephium_alephium_gpu_miner_1 ... error
Unknown runtime specified nvidia
ERROR: for alephium_gpu_miner  Cannot create container for service alephium_gpu_miner: Unknown runtime specified nvidia
ERROR: Encountered errors while bringing up the project.

Deleting the line "runtime: nvidia" solved this issue.