### PR TITLE
Log Storage Optimization

### DIFF
--- a/api/src/main/resources/openapi.json
+++ b/api/src/main/resources/openapi.json
@@ -7166,7 +7166,7 @@
         "tags": [
           "Events"
         ],
-        "summary": "Get events for a contract within a range of counters",
+        "summary": "Get events for a contract within a counter range",
         "operationId": "getEventsContract",
         "parameters": [
           {

--- a/api/src/main/resources/openapi.json
+++ b/api/src/main/resources/openapi.json
@@ -7161,20 +7161,28 @@
         }
       }
     },
-    "/events/contract/in-block": {
+    "/events/contract": {
       "get": {
         "tags": [
           "Events"
         ],
-        "summary": "Get events for a contract within a block",
-        "operationId": "getEventsContractIn-block",
+        "summary": "Get events for a contract within a range of counters",
+        "operationId": "getEventsContract",
         "parameters": [
           {
-            "name": "block",
+            "name": "start",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
             }
           },
           {
@@ -7288,290 +7296,6 @@
         }
       }
     },
-    "/events/contract/within-blocks": {
-      "get": {
-        "tags": [
-          "Events"
-        ],
-        "summary": "Get events for a contract within a range of blocks",
-        "operationId": "getEventsContractWithin-blocks",
-        "parameters": [
-          {
-            "name": "fromBlock",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "toBlock",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "contractAddress",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Events"
-                  }
-                },
-                "example": [
-                  {
-                    "chainFrom": 0,
-                    "chainTo": 1,
-                    "events": [
-                      {
-                        "type": "ContractEvent",
-                        "blockHash": "bdaf9dc514ce7d34b6474b8ca10a3dfb93ba997cb9d5ff1ea724ebe2af48abe5",
-                        "contractAddress": "z69mxCq5vnw7UZdN2iUDi2jqGRpfnSmgAuouvPeUXeMn",
-                        "txId": "109b05391a240a0d21671720f62fe39138aaca562676053900b348a51e11ba25",
-                        "eventIndex": 1,
-                        "fields": [
-                          {
-                            "type": "Address",
-                            "value": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y"
-                          },
-                          {
-                            "type": "U256",
-                            "value": "10"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequest",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                },
-                "example": {
-                  "detail": "Something bad in the request"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerError"
-                },
-                "example": {
-                  "detail": "Ouch"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                },
-                "example": {
-                  "resource": "wallet-name",
-                  "detail": "wallet-name not found"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailable"
-                },
-                "example": {
-                  "detail": "Self clique unsynced"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Unauthorized"
-                },
-                "example": {
-                  "detail": "You shall not pass"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/events/contract/within-time-interval": {
-      "get": {
-        "tags": [
-          "Events"
-        ],
-        "summary": "Get events for a contract within a time interval",
-        "operationId": "getEventsContractWithin-time-interval",
-        "parameters": [
-          {
-            "name": "fromTs",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": "0"
-            }
-          },
-          {
-            "name": "toTs",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": "0"
-            }
-          },
-          {
-            "name": "contractAddress",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Events"
-                  }
-                },
-                "example": [
-                  {
-                    "chainFrom": 0,
-                    "chainTo": 1,
-                    "events": [
-                      {
-                        "type": "ContractEvent",
-                        "blockHash": "bdaf9dc514ce7d34b6474b8ca10a3dfb93ba997cb9d5ff1ea724ebe2af48abe5",
-                        "contractAddress": "z69mxCq5vnw7UZdN2iUDi2jqGRpfnSmgAuouvPeUXeMn",
-                        "txId": "109b05391a240a0d21671720f62fe39138aaca562676053900b348a51e11ba25",
-                        "eventIndex": 1,
-                        "fields": [
-                          {
-                            "type": "Address",
-                            "value": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y"
-                          },
-                          {
-                            "type": "U256",
-                            "value": "10"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequest",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                },
-                "example": {
-                  "detail": "Something bad in the request"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerError"
-                },
-                "example": {
-                  "detail": "Ouch"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                },
-                "example": {
-                  "resource": "wallet-name",
-                  "detail": "wallet-name not found"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailable"
-                },
-                "example": {
-                  "detail": "Self clique unsynced"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Unauthorized"
-                },
-                "example": {
-                  "detail": "You shall not pass"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/events/tx-script": {
       "get": {
         "tags": [
@@ -7580,14 +7304,6 @@
         "summary": "Get events for a TxScript",
         "operationId": "getEventsTx-script",
         "parameters": [
-          {
-            "name": "block",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
           {
             "name": "txId",
             "in": "query",

--- a/api/src/main/resources/openapi.json
+++ b/api/src/main/resources/openapi.json
@@ -7296,6 +7296,103 @@
         }
       }
     },
+    "/events/contract/current-count": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "summary": "Get current value of the events counter for a contract",
+        "operationId": "getEventsContractCurrent-count",
+        "parameters": [
+          {
+            "name": "contractAddress",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                },
+                "example": 100
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/events/tx-script": {
       "get": {
         "tags": [
@@ -7343,6 +7440,103 @@
                     }
                   ]
                 }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/events/tx-script/current-count": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "summary": "Get current value of the events counter for a TxScript",
+        "operationId": "getEventsTx-scriptCurrent-count",
+        "parameters": [
+          {
+            "name": "txId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                },
+                "example": 100
               }
             }
           },

--- a/api/src/main/resources/openapi.json
+++ b/api/src/main/resources/openapi.json
@@ -7222,7 +7222,8 @@
                         }
                       ]
                     }
-                  ]
+                  ],
+                  "nextCount": 2
                 }
               }
             }
@@ -7438,7 +7439,8 @@
                         }
                       ]
                     }
-                  ]
+                  ],
+                  "nextCount": 2
                 }
               }
             }
@@ -8624,6 +8626,9 @@
             "items": {
               "$ref": "#/components/schemas/Event"
             }
+          },
+          "nextCount": {
+            "type": "integer"
           }
         }
       },

--- a/api/src/main/resources/openapi.json
+++ b/api/src/main/resources/openapi.json
@@ -7172,7 +7172,7 @@
           {
             "name": "start",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer"
             }

--- a/api/src/main/resources/openapi.json
+++ b/api/src/main/resources/openapi.json
@@ -7223,7 +7223,7 @@
                       ]
                     }
                   ],
-                  "nextCount": 2
+                  "nextStart": 2
                 }
               }
             }
@@ -7440,7 +7440,7 @@
                       ]
                     }
                   ],
-                  "nextCount": 2
+                  "nextStart": 2
                 }
               }
             }
@@ -8611,7 +8611,8 @@
         "required": [
           "chainFrom",
           "chainTo",
-          "events"
+          "events",
+          "nextStart"
         ],
         "type": "object",
         "properties": {
@@ -8627,7 +8628,7 @@
               "$ref": "#/components/schemas/Event"
             }
           },
-          "nextCount": {
+          "nextStart": {
             "type": "integer"
           }
         }

--- a/api/src/main/scala/org/alephium/api/Endpoints.scala
+++ b/api/src/main/scala/org/alephium/api/Endpoints.scala
@@ -444,6 +444,7 @@ trait Endpoints
 
   val getContractEventsCurrentCount: BaseEndpoint[Address.Contract, Int] =
     contractEventsEndpoint.get
+      .in("current-count")
       .in(query[Address.Contract]("contractAddress"))
       .out(jsonBody[Int])
       .summary("Get current value of the events counter for a contract")
@@ -456,6 +457,7 @@ trait Endpoints
 
   val getTxScriptEventsCurrentCount: BaseEndpoint[Hash, Int] =
     txScriptEventsEndpoint.get
+      .in("current-count")
       .in(query[Hash]("txId"))
       .out(jsonBody[Int])
       .summary("Get current value of the events counter for a TxScript")

--- a/api/src/main/scala/org/alephium/api/Endpoints.scala
+++ b/api/src/main/scala/org/alephium/api/Endpoints.scala
@@ -54,6 +54,14 @@ trait Endpoints
       )
       .validate(TimeInterval.validator)
 
+  private val counterQuery: EndpointInput[CounterRange] =
+    query[Option[Int]]("start")
+      .and(query[Option[Int]]("end"))
+      .map { case (fromOpt, toOpt) => CounterRange(fromOpt, toOpt) }(counterQuery =>
+        (counterQuery.startOpt, counterQuery.endOpt)
+      )
+      .validate(CounterRange.validator)
+
   private lazy val chainIndexQuery: EndpointInput[ChainIndex] =
     query[GroupIndex]("fromGroup")
       .and(query[GroupIndex]("toGroup"))
@@ -427,10 +435,9 @@ trait Endpoints
       .in("check-hash-indexing")
       .summary("Check and repair the indexing of block hashes")
 
-  val getContractEvents: BaseEndpoint[(Option[Int], Option[Int], Address.Contract), Events] =
+  val getContractEvents: BaseEndpoint[(CounterRange, Address.Contract), Events] =
     contractEventsEndpoint.get
-      .in(query[Option[Int]]("start"))
-      .in(query[Option[Int]]("end"))
+      .in(counterQuery)
       .in(query[Address.Contract]("contractAddress"))
       .out(jsonBody[Events])
       .summary("Get events for a contract within a range of counters")

--- a/api/src/main/scala/org/alephium/api/Endpoints.scala
+++ b/api/src/main/scala/org/alephium/api/Endpoints.scala
@@ -440,13 +440,25 @@ trait Endpoints
       .in(counterQuery)
       .in(query[Address.Contract]("contractAddress"))
       .out(jsonBody[Events])
-      .summary("Get events for a contract within a range of counters")
+      .summary("Get events for a contract within a counter range")
+
+  val getContractEventsCurrentCount: BaseEndpoint[Address.Contract, Int] =
+    contractEventsEndpoint.get
+      .in(query[Address.Contract]("contractAddress"))
+      .out(jsonBody[Int])
+      .summary("Get current value of the events counter for a contract")
 
   val getTxScriptEvents: BaseEndpoint[Hash, Events] =
     txScriptEventsEndpoint.get
       .in(query[Hash]("txId"))
       .out(jsonBody[Events])
       .summary("Get events for a TxScript")
+
+  val getTxScriptEventsCurrentCount: BaseEndpoint[Hash, Int] =
+    txScriptEventsEndpoint.get
+      .in(query[Hash]("txId"))
+      .out(jsonBody[Int])
+      .summary("Get current value of the events counter for a TxScript")
 }
 
 object Endpoints {

--- a/api/src/main/scala/org/alephium/api/Endpoints.scala
+++ b/api/src/main/scala/org/alephium/api/Endpoints.scala
@@ -427,37 +427,20 @@ trait Endpoints
       .in("check-hash-indexing")
       .summary("Check and repair the indexing of block hashes")
 
-  val getContractEventsForBlock: BaseEndpoint[(BlockHash, Address.Contract), Events] =
+  val getContractEvents
+      : BaseEndpoint[(Option[Int], Option[Int], Address.Contract, GroupIndex), Events] =
     contractEventsEndpoint.get
-      .in("in-block")
-      .in(query[BlockHash]("block"))
+      .in(query[Option[Int]]("start"))
+      .in(query[Option[Int]]("end"))
       .in(query[Address.Contract]("contractAddress"))
+      .in(query[GroupIndex]("group"))
       .out(jsonBody[Events])
-      .summary("Get events for a contract within a block")
+      .summary("Get events for a contract within a range of counters")
 
-  val getContractEventsWithinBlocks
-      : BaseEndpoint[(BlockHash, Option[BlockHash], Address.Contract), AVector[Events]] =
-    contractEventsEndpoint.get
-      .in("within-blocks")
-      .in(query[BlockHash]("fromBlock"))
-      .in(query[Option[BlockHash]]("toBlock"))
-      .in(query[Address.Contract]("contractAddress"))
-      .out(jsonBody[AVector[Events]])
-      .summary("Get events for a contract within a range of blocks")
-
-  val getContractEventsWithinTimeInterval
-      : BaseEndpoint[(TimeInterval, Address.Contract), AVector[Events]] =
-    contractEventsEndpoint.get
-      .in("within-time-interval")
-      .in(timeIntervalQuery)
-      .in(query[Address.Contract]("contractAddress"))
-      .out(jsonBody[AVector[Events]])
-      .summary("Get events for a contract within a time interval")
-
-  val getTxScriptEvents: BaseEndpoint[(BlockHash, Hash), Events] =
+  val getTxScriptEvents: BaseEndpoint[(Hash, GroupIndex), Events] =
     txScriptEventsEndpoint.get
-      .in(query[BlockHash]("block"))
       .in(query[Hash]("txId"))
+      .in(query[GroupIndex]("group"))
       .out(jsonBody[Events])
       .summary("Get events for a TxScript")
 }

--- a/api/src/main/scala/org/alephium/api/Endpoints.scala
+++ b/api/src/main/scala/org/alephium/api/Endpoints.scala
@@ -427,20 +427,17 @@ trait Endpoints
       .in("check-hash-indexing")
       .summary("Check and repair the indexing of block hashes")
 
-  val getContractEvents
-      : BaseEndpoint[(Option[Int], Option[Int], Address.Contract, GroupIndex), Events] =
+  val getContractEvents: BaseEndpoint[(Option[Int], Option[Int], Address.Contract), Events] =
     contractEventsEndpoint.get
       .in(query[Option[Int]]("start"))
       .in(query[Option[Int]]("end"))
       .in(query[Address.Contract]("contractAddress"))
-      .in(query[GroupIndex]("group"))
       .out(jsonBody[Events])
       .summary("Get events for a contract within a range of counters")
 
-  val getTxScriptEvents: BaseEndpoint[(Hash, GroupIndex), Events] =
+  val getTxScriptEvents: BaseEndpoint[Hash, Events] =
     txScriptEventsEndpoint.get
       .in(query[Hash]("txId"))
-      .in(query[GroupIndex]("group"))
       .out(jsonBody[Events])
       .summary("Get events for a TxScript")
 }

--- a/api/src/main/scala/org/alephium/api/Endpoints.scala
+++ b/api/src/main/scala/org/alephium/api/Endpoints.scala
@@ -55,10 +55,10 @@ trait Endpoints
       .validate(TimeInterval.validator)
 
   private val counterQuery: EndpointInput[CounterRange] =
-    query[Option[Int]]("start")
+    query[Int]("start")
       .and(query[Option[Int]]("end"))
-      .map { case (fromOpt, toOpt) => CounterRange(fromOpt, toOpt) }(counterQuery =>
-        (counterQuery.startOpt, counterQuery.endOpt)
+      .map { case (start, endOpt) => CounterRange(start, endOpt) }(counterQuery =>
+        (counterQuery.start, counterQuery.endOpt)
       )
       .validate(CounterRange.validator)
 

--- a/api/src/main/scala/org/alephium/api/EndpointsExamples.scala
+++ b/api/src/main/scala/org/alephium/api/EndpointsExamples.scala
@@ -617,9 +617,9 @@ trait EndpointsExamples extends ErrorExamples {
     simpleExample(VerifySignature(Hex.unsafe(hexString), signature, publicKey))
 
   implicit val eventsExamples: List[Example[Events]] =
-    simpleExample(Events(0, 1, events = AVector(event), Some(2)))
+    simpleExample(Events(0, 1, events = AVector(event), 2))
 
   implicit val eventsVectorExamples: List[Example[AVector[Events]]] =
-    simpleExample(AVector(Events(0, 1, events = AVector(event), Some(3))))
+    simpleExample(AVector(Events(0, 1, events = AVector(event), 3)))
 }
 // scalastyle:on magic.number

--- a/api/src/main/scala/org/alephium/api/EndpointsExamples.scala
+++ b/api/src/main/scala/org/alephium/api/EndpointsExamples.scala
@@ -617,9 +617,9 @@ trait EndpointsExamples extends ErrorExamples {
     simpleExample(VerifySignature(Hex.unsafe(hexString), signature, publicKey))
 
   implicit val eventsExamples: List[Example[Events]] =
-    simpleExample(Events(0, 1, events = AVector(event)))
+    simpleExample(Events(0, 1, events = AVector(event), Some(2)))
 
   implicit val eventsVectorExamples: List[Example[AVector[Events]]] =
-    simpleExample(AVector(Events(0, 1, events = AVector(event))))
+    simpleExample(AVector(Events(0, 1, events = AVector(event), Some(3))))
 }
 // scalastyle:on magic.number

--- a/api/src/main/scala/org/alephium/api/EndpointsExamples.scala
+++ b/api/src/main/scala/org/alephium/api/EndpointsExamples.scala
@@ -610,6 +610,9 @@ trait EndpointsExamples extends ErrorExamples {
   implicit val booleanExamples: List[Example[Boolean]] =
     simpleExample(true)
 
+  implicit val intExamples: List[Example[Int]] =
+    simpleExample(100)
+
   implicit val verifySignatureExamples: List[Example[VerifySignature]] =
     simpleExample(VerifySignature(Hex.unsafe(hexString), signature, publicKey))
 

--- a/api/src/main/scala/org/alephium/api/model/CounterRange.scala
+++ b/api/src/main/scala/org/alephium/api/model/CounterRange.scala
@@ -21,14 +21,28 @@ import sttp.tapir.{ValidationError, Validator}
 final case class CounterRange(start: Int, endOpt: Option[Int])
 
 object CounterRange {
+  val MaxCounterRange: Int = 100
+
   val validator: Validator[CounterRange] = Validator.custom { counterRange =>
     if (counterRange.start < 0) {
       List(ValidationError.Custom(counterRange, s"`start` must not be negative"))
     } else {
-      if (counterRange.endOpt.exists(_ <= counterRange.start)) {
-        List(ValidationError.Custom(counterRange, s"`end` must be larger than `start`"))
-      } else {
-        List.empty
+      counterRange.endOpt match {
+        case Some(end) =>
+          if (end <= counterRange.start) {
+            List(ValidationError.Custom(counterRange, s"`end` must be larger than `start`"))
+          } else if (end - counterRange.start > MaxCounterRange) {
+            List(
+              ValidationError.Custom(
+                counterRange,
+                s"`end` must be smaller than ${counterRange.start + MaxCounterRange}"
+              )
+            )
+          } else {
+            List.empty
+          }
+        case None =>
+          List.empty
       }
     }
   }

--- a/api/src/main/scala/org/alephium/api/model/CounterRange.scala
+++ b/api/src/main/scala/org/alephium/api/model/CounterRange.scala
@@ -1,0 +1,37 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.api.model
+
+import sttp.tapir.{ValidationError, Validator}
+
+final case class CounterRange(startOpt: Option[Int], endOpt: Option[Int]) {
+  def start: Int = startOpt.getOrElse(0)
+}
+
+object CounterRange {
+  val validator: Validator[CounterRange] = Validator.custom { counterRange =>
+    if (counterRange.start < 0) {
+      List(ValidationError.Custom(counterRange, s"`start` must not be negative"))
+    } else {
+      if (counterRange.endOpt.exists(_ <= counterRange.start)) {
+        List(ValidationError.Custom(counterRange, s"`end` must be larger than `start`"))
+      } else {
+        List.empty
+      }
+    }
+  }
+}

--- a/api/src/main/scala/org/alephium/api/model/CounterRange.scala
+++ b/api/src/main/scala/org/alephium/api/model/CounterRange.scala
@@ -18,9 +18,7 @@ package org.alephium.api.model
 
 import sttp.tapir.{ValidationError, Validator}
 
-final case class CounterRange(startOpt: Option[Int], endOpt: Option[Int]) {
-  def start: Int = startOpt.getOrElse(0)
-}
+final case class CounterRange(start: Int, endOpt: Option[Int])
 
 object CounterRange {
   val validator: Validator[CounterRange] = Validator.custom { counterRange =>

--- a/api/src/main/scala/org/alephium/api/model/CounterRange.scala
+++ b/api/src/main/scala/org/alephium/api/model/CounterRange.scala
@@ -42,7 +42,16 @@ object CounterRange {
             List.empty
           }
         case None =>
-          List.empty
+          if (counterRange.start > Int.MaxValue - MaxCounterRange) {
+            List(
+              ValidationError.Custom(
+                counterRange,
+                s"`start` must be smaller than ${Int.MaxValue - MaxCounterRange}"
+              )
+            )
+          } else {
+            List.empty
+          }
       }
     }
   }

--- a/api/src/main/scala/org/alephium/api/model/Events.scala
+++ b/api/src/main/scala/org/alephium/api/model/Events.scala
@@ -25,7 +25,7 @@ final case class Events(
     chainFrom: Int,
     chainTo: Int,
     events: AVector[Event],
-    nextCount: Option[Int]
+    nextStart: Int
 )
 
 sealed trait Event {

--- a/api/src/main/scala/org/alephium/api/model/Events.scala
+++ b/api/src/main/scala/org/alephium/api/model/Events.scala
@@ -17,14 +17,15 @@
 package org.alephium.api.model
 
 import org.alephium.protocol.{BlockHash, Hash}
-import org.alephium.protocol.model.{Address, ChainIndex, ContractId}
+import org.alephium.protocol.model.{Address, ContractId}
 import org.alephium.protocol.vm.LogStates
 import org.alephium.util.AVector
 
 final case class Events(
     chainFrom: Int,
     chainTo: Int,
-    events: AVector[Event]
+    events: AVector[Event],
+    nextCount: Option[Int]
 )
 
 sealed trait Event {
@@ -73,13 +74,5 @@ object Events {
         )
       }
     }
-  }
-
-  def from(chainIndex: ChainIndex, logStates: LogStates): Events = {
-    Events(chainIndex.from.value, chainIndex.to.value, Events.from(logStates))
-  }
-
-  def empty(chainIndex: ChainIndex): Events = {
-    Events(chainIndex.from.value, chainIndex.to.value, events = AVector.empty)
   }
 }

--- a/api/src/main/scala/org/alephium/api/package.scala
+++ b/api/src/main/scala/org/alephium/api/package.scala
@@ -31,6 +31,7 @@ import org.alephium.protocol.vm.ExeResult
 package object api {
   type Try[T] = Either[ApiError[_ <: StatusCode], T]
 
+  def notFound(error: String): ApiError[_ <: StatusCode]   = ApiError.NotFound(error)
   def badRequest(error: String): ApiError[_ <: StatusCode] = ApiError.BadRequest(error)
   def failed(error: String): ApiError[_ <: StatusCode] =
     ApiError.InternalServerError(error)

--- a/app/src/it/scala/org/alephium/app/BroadcastTxTest.scala
+++ b/app/src/it/scala/org/alephium/app/BroadcastTxTest.scala
@@ -33,7 +33,7 @@ class BroadcastTxTest extends AlephiumActorSpec {
     val restPort1 = clique.getServer(tx.fromGroup).config.network.restPort
     val restPort2 = clique.getServer((tx.fromGroup + 1) % groups0).config.network.restPort
     eventually(request[TxStatus](getTransactionStatus(tx), restPort1) is MemPooled)
-    eventually(requestFailed(getTransactionStatus(tx), restPort2, StatusCode.BadRequest))
+    eventually(requestFailed(getTransactionStatus(tx), restPort2, StatusCode.InternalServerError))
 
     clique.stop()
   }

--- a/app/src/it/scala/org/alephium/app/BroadcastTxTest.scala
+++ b/app/src/it/scala/org/alephium/app/BroadcastTxTest.scala
@@ -31,7 +31,7 @@ class BroadcastTxTest extends AlephiumActorSpec {
     val restPort1 = clique.getServer(tx.fromGroup).config.network.restPort
     val restPort2 = clique.getServer((tx.fromGroup + 1) % groups0).config.network.restPort
     eventually(request[TxStatus](getTransactionStatus(tx), restPort1) is MemPooled)
-    eventually(request[TxStatus](getTransactionStatus(tx), restPort1) is TxNotFound)
+    eventually(request[TxStatus](getTransactionStatus(tx), restPort2) is TxNotFound)
 
     clique.stop()
   }

--- a/app/src/it/scala/org/alephium/app/BroadcastTxTest.scala
+++ b/app/src/it/scala/org/alephium/app/BroadcastTxTest.scala
@@ -18,8 +18,6 @@ package org.alephium.app
 
 import java.net.InetSocketAddress
 
-import sttp.model.StatusCode
-
 import org.alephium.api.model._
 import org.alephium.protocol.model.BrokerInfo
 import org.alephium.util._
@@ -33,7 +31,7 @@ class BroadcastTxTest extends AlephiumActorSpec {
     val restPort1 = clique.getServer(tx.fromGroup).config.network.restPort
     val restPort2 = clique.getServer((tx.fromGroup + 1) % groups0).config.network.restPort
     eventually(request[TxStatus](getTransactionStatus(tx), restPort1) is MemPooled)
-    eventually(requestFailed(getTransactionStatus(tx), restPort2, StatusCode.InternalServerError))
+    eventually(request[TxStatus](getTransactionStatus(tx), restPort1) is TxNotFound)
 
     clique.stop()
   }

--- a/app/src/it/scala/org/alephium/app/CliqueFixture.scala
+++ b/app/src/it/scala/org/alephium/app/CliqueFixture.scala
@@ -616,6 +616,12 @@ class CliqueFixture(implicit spec: AlephiumActorSpec)
     httpGet(s"/wallets/${walletName}/miner-addresses")
   }
 
+  def isBlockInMainChain(blockHash: String) = {
+    httpGet(
+      s"/blockflow/is-block-in-main-chain?blockHash=$blockHash"
+    )
+  }
+
   def convertFields(fields: AVector[Val]): String = {
     fields.map(write[Val](_)).mkString("[", ",", "]")
   }

--- a/app/src/it/scala/org/alephium/app/CliqueFixture.scala
+++ b/app/src/it/scala/org/alephium/app/CliqueFixture.scala
@@ -581,9 +581,9 @@ class CliqueFixture(implicit spec: AlephiumActorSpec)
     httpGet(s"/contracts/${address}/state?group=${group}")
   }
 
-  def getEventsWithinTimeInterval(startTs: TimeStamp, toTs: TimeStamp, address: Address) = {
+  def getContractEvents(start: Int, address: Address) = {
     httpGet(
-      s"/events/contract/within-time-interval?fromTs=${startTs.millis}&toTs=${toTs.millis}&contractAddress=${address.toBase58}"
+      s"/events/contract?start=$start&contractAddress=${address.toBase58}"
     )
   }
 

--- a/app/src/it/scala/org/alephium/app/CliqueFixture.scala
+++ b/app/src/it/scala/org/alephium/app/CliqueFixture.scala
@@ -587,6 +587,12 @@ class CliqueFixture(implicit spec: AlephiumActorSpec)
     )
   }
 
+  def getContractEventsCurrentCount(address: Address) = {
+    httpGet(
+      s"/events/contract/current-count?contractAddress=${address.toBase58}"
+    )
+  }
+
   def multisig(keys: AVector[String], mrequired: Int) = {
     val body = s"""
         |{

--- a/app/src/it/scala/org/alephium/app/VotingTest.scala
+++ b/app/src/it/scala/org/alephium/app/VotingTest.scala
@@ -40,7 +40,7 @@ class VotingTest extends AlephiumActorSpec {
       allEvents.length is 1
       checkVotingStartedEvent(allEvents.head)
     }
-    checkEventsCurrentCount(contractAddress) is 1
+    val countAfterVotingStarted = getEventsCurrentCount(contractAddress)
 
     val nbYes = voters.size - 1
     val nbNo  = voters.size - nbYes
@@ -48,20 +48,19 @@ class VotingTest extends AlephiumActorSpec {
     voters.drop(nbYes).foreach(wallet => vote(wallet, contractId.toHexString, false, contractCode))
     checkState(nbYes, nbNo, false, true)
 
-    checkEvents(contractAddress, 1) { response =>
+    checkEvents(contractAddress, countAfterVotingStarted) { response =>
       checkVoteCastedEvents(response.events)
     }
-    checkEventsCurrentCount(contractAddress) is 1 + voters.length
+    val countAfterVotingCasted = getEventsCurrentCount(contractAddress)
 
     close(admin, contractId.toHexString, contractCode)
     checkState(nbYes, nbNo, true, true)
 
-    checkEvents(contractAddress, 1 + voters.length) { response =>
+    checkEvents(contractAddress, countAfterVotingCasted) { response =>
       val allEvents = response.events
       allEvents.length is 1
       checkVotingClosedEvent(allEvents.head)
     }
-    checkEventsCurrentCount(contractAddress) is 2 + voters.length
 
     // Check all events for the contract from the beginning
     checkEvents(contractAddress, 0) { response =>
@@ -136,7 +135,7 @@ class VotingTest extends AlephiumActorSpec {
       validate(events)
     }
 
-    def checkEventsCurrentCount(contractAddress: Address): Int = {
+    def getEventsCurrentCount(contractAddress: Address): Int = {
       request[Int](getContractEventsCurrentCount(contractAddress), restPort)
     }
   }

--- a/app/src/main/scala/org/alephium/app/Documentation.scala
+++ b/app/src/main/scala/org/alephium/app/Documentation.scala
@@ -71,7 +71,9 @@ trait Documentation extends Endpoints with OpenAPIDocsInterpreter {
     minerListAddresses,
     minerUpdateAddresses,
     getContractEvents,
-    getTxScriptEvents
+    getContractEventsCurrentCount,
+    getTxScriptEvents,
+    getTxScriptEventsCurrentCount
   )
 
   private lazy val servers = List(

--- a/app/src/main/scala/org/alephium/app/Documentation.scala
+++ b/app/src/main/scala/org/alephium/app/Documentation.scala
@@ -70,9 +70,7 @@ trait Documentation extends Endpoints with OpenAPIDocsInterpreter {
     minerAction,
     minerListAddresses,
     minerUpdateAddresses,
-    getContractEventsForBlock,
-    getContractEventsWithinBlocks,
-    getContractEventsWithinTimeInterval,
+    getContractEvents,
     getTxScriptEvents
   )
 

--- a/app/src/main/scala/org/alephium/app/EndpointsLogic.scala
+++ b/app/src/main/scala/org/alephium/app/EndpointsLogic.scala
@@ -572,33 +572,23 @@ trait EndpointsLogic extends Endpoints with EndpointSender with SttpClientInterp
     }
   }
 
-  val getContractEventsForBlockLogic = serverLogic(getContractEventsForBlock) {
-    case (blockHash, contractAddress) =>
+  val getContractEventsLogic = serverLogic(getContractEvents) {
+    case (startOpt, endOpt, contractAddress, groupIndex) =>
       Future.successful {
         val contractId = contractAddress.lockupScript.contractId
-        serverUtils.getEventsForBlock(blockFlow, blockHash, contractId)
+        serverUtils.getEvents(
+          blockFlow,
+          startOpt.getOrElse(0),
+          endOpt,
+          groupIndex,
+          contractId
+        )
       }
   }
 
-  val getContractEventsWithinBlocksLogic = serverLogic(getContractEventsWithinBlocks) {
-    case (fromBlock, toBlockOpt, contractAddress) =>
-      Future.successful {
-        val contractId = contractAddress.lockupScript.contractId
-        serverUtils.getContractEventsWithinBlocks(blockFlow, fromBlock, toBlockOpt, contractId)
-      }
-  }
-
-  val getContractEventsWithinTimeIntervalLogic = serverLogic(getContractEventsWithinTimeInterval) {
-    case (timeInterval, contractAddress) =>
-      Future.successful {
-        val contractId = contractAddress.lockupScript.contractId
-        serverUtils.getContractEventsWithinTimeInterval(blockFlow, timeInterval, contractId)
-      }
-  }
-
-  val getTxScriptEventsLogic = serverLogic(getTxScriptEvents) { case (blockHash, txId) =>
+  val getTxScriptEventsLogic = serverLogic(getTxScriptEvents) { case (txId, groupIndex) =>
     Future.successful {
-      serverUtils.getEventsForBlock(blockFlow, blockHash, txId)
+      serverUtils.getEvents(blockFlow, 0, None, groupIndex, txId)
     }
   }
 

--- a/app/src/main/scala/org/alephium/app/EndpointsLogic.scala
+++ b/app/src/main/scala/org/alephium/app/EndpointsLogic.scala
@@ -568,9 +568,22 @@ trait EndpointsLogic extends Endpoints with EndpointSender with SttpClientInterp
       }
   }
 
-  val getTxScriptEventsLogic = serverLogic(getTxScriptEvents) { case txId =>
+  val getContractEventsCurrentCountLogic = serverLogic(getContractEventsCurrentCount) {
+    contractAddress =>
+      Future.successful {
+        serverUtils.getEventsForContractCurrentCount(blockFlow, contractAddress)
+      }
+  }
+
+  val getTxScriptEventsLogic = serverLogic(getTxScriptEvents) { txId =>
     Future.successful {
       serverUtils.getEventsForTxScript(blockFlow, txId)
+    }
+  }
+
+  val getTxScriptEventsCurrentCountLogic = serverLogic(getTxScriptEventsCurrentCount) { txId =>
+    Future.successful {
+      serverUtils.getEventsForTxScriptCurrentCount(blockFlow, txId)
     }
   }
 

--- a/app/src/main/scala/org/alephium/app/EndpointsLogic.scala
+++ b/app/src/main/scala/org/alephium/app/EndpointsLogic.scala
@@ -556,13 +556,13 @@ trait EndpointsLogic extends Endpoints with EndpointSender with SttpClientInterp
   }
 
   val getContractEventsLogic = serverLogic(getContractEvents) {
-    case (startOpt, endOpt, contractAddress) =>
+    case (counterRange, contractAddress) =>
       Future.successful {
         val contractId = contractAddress.lockupScript.contractId
         serverUtils.getEventsForContract(
           blockFlow,
-          startOpt.getOrElse(0),
-          endOpt,
+          counterRange.start,
+          counterRange.endOpt,
           contractId
         )
       }
@@ -570,7 +570,7 @@ trait EndpointsLogic extends Endpoints with EndpointSender with SttpClientInterp
 
   val getTxScriptEventsLogic = serverLogic(getTxScriptEvents) { case txId =>
     Future.successful {
-      serverUtils.getEventsForTxScript(blockFlow, 0, None, txId)
+      serverUtils.getEventsForTxScript(blockFlow, txId)
     }
   }
 

--- a/app/src/main/scala/org/alephium/app/RestServer.scala
+++ b/app/src/main/scala/org/alephium/app/RestServer.scala
@@ -108,7 +108,9 @@ class RestServer(
       verifySignatureLogic,
       checkHashIndexingLogic,
       getContractEventsLogic,
+      getContractEventsCurrentCountLogic,
       getTxScriptEventsLogic,
+      getTxScriptEventsCurrentCountLogic,
       metricsLogic
     ).map(route(_)) :+ swaggerUiRoute
 

--- a/app/src/main/scala/org/alephium/app/RestServer.scala
+++ b/app/src/main/scala/org/alephium/app/RestServer.scala
@@ -107,9 +107,7 @@ class RestServer(
       exportBlocksLogic,
       verifySignatureLogic,
       checkHashIndexingLogic,
-      getContractEventsForBlockLogic,
-      getContractEventsWithinBlocksLogic,
-      getContractEventsWithinTimeIntervalLogic,
+      getContractEventsLogic,
       getTxScriptEventsLogic,
       metricsLogic
     ).map(route(_)) :+ swaggerUiRoute

--- a/app/src/main/scala/org/alephium/app/ServerUtils.scala
+++ b/app/src/main/scala/org/alephium/app/ServerUtils.scala
@@ -146,14 +146,13 @@ class ServerUtils(implicit
   }
 
   def getGroupForContract(blockFlow: BlockFlow, contractId: ContractId): Try[Group] = {
-    val failure: Try[Group] = Left(failed("Group not found.")).withRight[Group]
-    brokerConfig.groupRange.foldLeft(failure) { case (prevResult, currentGroup: Int) =>
-      prevResult match {
-        case Right(prevResult) => Right(prevResult)
-        case Left(_) =>
-          getContractGroup(blockFlow, contractId, GroupIndex.unsafe(currentGroup))
+    blockFlow
+      .getGroupForContract(contractId)
+      .map { groupIndex =>
+        Group(groupIndex.value)
       }
-    }
+      .left
+      .map(failed)
   }
 
   def listUnconfirmedTransactions(

--- a/app/src/main/scala/org/alephium/app/ServerUtils.scala
+++ b/app/src/main/scala/org/alephium/app/ServerUtils.scala
@@ -499,9 +499,13 @@ class ServerUtils(implicit
         .getEvents(chainIndex, eventKey, start, endOpt)(
           isBlockInMainChain(blockFlow, _).contains(true)
         )
-        .map(_.flatMap(Events.from))
-        .map { events =>
-          Events(chainIndex.from.value, chainIndex.to.value, events)
+        .map { case (nextCount, logStatesVec) =>
+          Events(
+            chainIndex.from.value,
+            chainIndex.to.value,
+            logStatesVec.flatMap(Events.from),
+            nextCount
+          )
         }
     )
   }

--- a/app/src/main/scala/org/alephium/app/ServerUtils.scala
+++ b/app/src/main/scala/org/alephium/app/ServerUtils.scala
@@ -502,12 +502,12 @@ class ServerUtils(implicit
           start,
           endOpt.getOrElse(start + CounterRange.MaxCounterRange)
         )
-        .map { case (nextCount, logStatesVec) =>
+        .map { case (nextStart, logStatesVec) =>
           Events(
             chainIndex.from.value,
             chainIndex.to.value,
             logStatesVec.flatMap(Events.from),
-            nextCount
+            nextStart
           )
         }
     )

--- a/app/src/main/scala/org/alephium/app/ServerUtils.scala
+++ b/app/src/main/scala/org/alephium/app/ServerUtils.scala
@@ -497,17 +497,10 @@ class ServerUtils(implicit
   ): Try[Events] = {
     wrapResult(
       blockFlow
-        .getEvents(chainIndex, eventKey, start, endOpt)
-        .map {
-          _.flatMap { logStates =>
-            val inMainChain = isBlockInMainChain(blockFlow, logStates.blockHash).contains(true)
-            if (inMainChain) {
-              Events.from(logStates)
-            } else {
-              AVector.empty[Event]
-            }
-          }
-        }
+        .getEvents(chainIndex, eventKey, start, endOpt)(
+          isBlockInMainChain(blockFlow, _).contains(true)
+        )
+        .map(_.flatMap(Events.from))
         .map { events =>
           Events(chainIndex.from.value, chainIndex.to.value, events)
         }

--- a/app/src/main/scala/org/alephium/app/ServerUtils.scala
+++ b/app/src/main/scala/org/alephium/app/ServerUtils.scala
@@ -496,7 +496,12 @@ class ServerUtils(implicit
   ): Try[Events] = {
     wrapResult(
       blockFlow
-        .getEvents(chainIndex, eventKey, start, endOpt)(
+        .getEvents(
+          chainIndex,
+          eventKey,
+          start,
+          endOpt.getOrElse(start + CounterRange.MaxCounterRange)
+        )(
           isBlockInMainChain(blockFlow, _).contains(true)
         )
         .map { case (nextCount, logStatesVec) =>

--- a/app/src/main/scala/org/alephium/app/ServerUtils.scala
+++ b/app/src/main/scala/org/alephium/app/ServerUtils.scala
@@ -363,7 +363,7 @@ class ServerUtils(implicit
       blockFlow: BlockFlow,
       start: Int,
       endOpt: Option[Int],
-      contractId: Hash
+      contractId: ContractId
   ): Try[Events] = {
     for {
       groupIndex <- blockFlow.getGroupForContract(contractId).left.map(failed)

--- a/app/src/main/scala/org/alephium/app/ServerUtils.scala
+++ b/app/src/main/scala/org/alephium/app/ServerUtils.scala
@@ -501,8 +501,6 @@ class ServerUtils(implicit
           eventKey,
           start,
           endOpt.getOrElse(start + CounterRange.MaxCounterRange)
-        )(
-          isBlockInMainChain(blockFlow, _).contains(true)
         )
         .map { case (nextCount, logStatesVec) =>
           Events(

--- a/app/src/main/scala/org/alephium/app/ServerUtils.scala
+++ b/app/src/main/scala/org/alephium/app/ServerUtils.scala
@@ -498,7 +498,16 @@ class ServerUtils(implicit
     wrapResult(
       blockFlow
         .getEvents(chainIndex, eventKey, start, endOpt)
-        .map(_.flatMap(Events.from))
+        .map {
+          _.flatMap { logStates =>
+            val inMainChain = isBlockInMainChain(blockFlow, logStates.blockHash).contains(true)
+            if (inMainChain) {
+              Events.from(logStates)
+            } else {
+              AVector.empty[Event]
+            }
+          }
+        }
         .map { events =>
           Events(chainIndex.from.value, chainIndex.to.value, events)
         }

--- a/app/src/test/scala/org/alephium/app/RestServerSpec.scala
+++ b/app/src/test/scala/org/alephium/app/RestServerSpec.scala
@@ -789,7 +789,8 @@ abstract class RestServerSpec(
         |        }
         |      ]
         |    }
-        |  ]
+        |  ],
+        |  "nextCount": 2
         |}
         |""".stripMargin.filterNot(_.isWhitespace)
     }
@@ -835,7 +836,8 @@ abstract class RestServerSpec(
         |        }
         |      ]
         |    }
-        |  ]
+        |  ],
+        |  "nextCount": 2
         |}
         |""".stripMargin.filterNot(_.isWhitespace)
         } else {

--- a/app/src/test/scala/org/alephium/app/RestServerSpec.scala
+++ b/app/src/test/scala/org/alephium/app/RestServerSpec.scala
@@ -373,8 +373,8 @@ abstract class RestServerSpec(
             response.code is StatusCode.Ok
             status is dummyTxStatus
           } else {
-            response.code is StatusCode.BadRequest
-            response.as[ApiError.BadRequest] is ApiError.BadRequest(
+            response.code is StatusCode.InternalServerError
+            response.as[ApiError.InternalServerError] is ApiError.InternalServerError(
               s"${txId.toHexString} belongs to other groups"
             )
           }
@@ -742,130 +742,26 @@ abstract class RestServerSpec(
     }
   }
 
-  it should "get events for a contract from a given block" in {
-    val block = blockGen
-      .map(_.header.copy(timestamp = (TimeStamp.now() - Duration.ofMinutes(5).get).get))
-      .retryUntil(_.chainIndex.isIntraGroup)
-      .sample
-      .get
-    val blockHash  = block.hash.toHexString
-    val chainIndex = block.chainIndex
+  it should "get events for a contract within a counter range" in {
+    val blockHash  = dummyBlock.hash
+    val start      = 10
+    val end        = 100
+    val urlBase    = s"/events/contract?contractAddress=$dummyContractAddress"
+    val chainIndex = ChainIndex.unsafe(0, 0)
 
-    Get(s"/events/contract/in-block?block=$blockHash&contractAddress=$dummyContractAddress") check {
-      response =>
-        response.code is StatusCode.Ok
-        val events = response.body.rightValue
-        events is s"""
-        |{
-        |  "chainFrom": ${chainIndex.from.value},
-        |  "chainTo": ${chainIndex.to.value},
-        |  "events": [
-        |    {
-        |      "type": "ContractEvent",
-        |      "blockHash": "$blockHash",
-        |      "contractAddress": "${dummyContractAddress}",
-        |      "txId": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
-        |      "eventIndex": 0,
-        |      "fields": [
-        |        {
-        |          "type": "U256",
-        |          "value": "4"
-        |        },
-        |        {
-        |          "type": "Address",
-        |          "value": "16BCZkZzGb3QnycJQefDHqeZcTA5RhrwYUDsAYkCf7RhS"
-        |        },
-        |        {
-        |          "type": "Address",
-        |          "value": "27gAhB8JB6UtE9tC3PwGRbXHiZJ9ApuCMoHqe1T4VzqFi"
-        |        }
-        |      ]
-        |    }
-        |  ]
-        |}
-        |""".stripMargin.filterNot(_.isWhitespace)
-    }
-  }
+    info("with valid start and end")
+    Get(s"$urlBase&start=$start&end=$end").check(validResponse)
 
-  it should "get events for a contract within a time interval" in {
-    val blockHash  = dummyBlock.hash.toHexString
-    val chainIndex = dummyBlock.chainIndex
+    info("with start only")
+    Get(s"$urlBase&start=$start").check(validResponse)
 
-    val now    = TimeStamp.now()
-    val fromTs = (now - Duration.ofMinutes(10).get).get
-    val toTs   = (now - Duration.ofMinutes(3).get).get
-
-    val urlBase = s"/events/contract/within-time-interval?contractAddress=$dummyContractAddress"
-
-    info("with valid fromTs and toTs")
-    Get(s"$urlBase&fromTs=${fromTs.millis}&toTs=${toTs.millis}").check(validResponse)
-
-    info("with fromTs only")
-    Get(s"$urlBase&fromTs=${fromTs.millis}").check(validResponse)
-
-    info("with invalid fromTs and toTs")
-    Get(s"$urlBase&fromTs=${toTs.millis}&toTs=${fromTs.millis}").check { response =>
+    info("with invalid start and end")
+    Get(s"$urlBase&start=$end&end=$start").check { response =>
       response.code is StatusCode.BadRequest
-      response.body.leftValue is s"""{"detail":"Invalid value (`fromTs` must be before `toTs`)"}"""
+      response.body.leftValue is s"""{"detail":"Invalid value (`end` must be larger than `start`)"}"""
     }
 
     def validResponse(response: Response[Either[String, String]]): Assertion = {
-      response.code is StatusCode.Ok
-      val events = response.body.rightValue
-      if (dummyBlock.chainIndex.isIntraGroup) {
-        events is s"""
-        |[{
-        |  "chainFrom": ${chainIndex.from.value},
-        |  "chainTo": ${chainIndex.to.value},
-        |  "events": [
-        |    {
-        |      "type": "ContractEvent",
-        |      "blockHash": "$blockHash",
-        |      "contractAddress": "${dummyContractAddress}",
-        |      "txId": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
-        |      "eventIndex": 0,
-        |      "fields": [
-        |        {
-        |          "type": "U256",
-        |          "value": "4"
-        |        },
-        |        {
-        |          "type": "Address",
-        |          "value": "16BCZkZzGb3QnycJQefDHqeZcTA5RhrwYUDsAYkCf7RhS"
-        |        },
-        |        {
-        |          "type": "Address",
-        |          "value": "27gAhB8JB6UtE9tC3PwGRbXHiZJ9ApuCMoHqe1T4VzqFi"
-        |        }
-        |      ]
-        |    }
-        |  ]
-        |}]
-        |""".stripMargin.filterNot(_.isWhitespace)
-      } else {
-        events is s"""
-        |[{
-        |  "chainFrom": ${chainIndex.from.value},
-        |  "chainTo": ${chainIndex.to.value},
-        |  "events": [
-        |  ]
-        |}]
-        |""".stripMargin.filterNot(_.isWhitespace)
-      }
-    }
-  }
-
-  it should "get events for a TxScript from a given block" in {
-    val block = blockGen
-      .map(_.header.copy(timestamp = (TimeStamp.now() - Duration.ofMinutes(5).get).get))
-      .retryUntil(_.chainIndex.isIntraGroup)
-      .sample
-      .get
-    val blockHash  = block.hash.toHexString
-    val chainIndex = block.chainIndex
-    val txId       = "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69"
-
-    Get(s"/events/tx-script?block=$blockHash&txId=${txId}") check { response =>
       response.code is StatusCode.Ok
       val events = response.body.rightValue
       events is s"""
@@ -874,9 +770,10 @@ abstract class RestServerSpec(
         |  "chainTo": ${chainIndex.to.value},
         |  "events": [
         |    {
-        |      "type": "TxScriptEvent",
-        |      "blockHash": "$blockHash",
-        |      "txId": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
+        |      "type": "ContractEvent",
+        |      "blockHash": "${blockHash.toHexString}",
+        |      "contractAddress": "${dummyContractAddress}",
+        |      "txId": "${dummyTx.id.toHexString}",
         |      "eventIndex": 0,
         |      "fields": [
         |        {
@@ -896,6 +793,58 @@ abstract class RestServerSpec(
         |  ]
         |}
         |""".stripMargin.filterNot(_.isWhitespace)
+    }
+  }
+
+  it should "get events for a TxScript" in {
+    val blockHash = dummyBlock.hash
+    val txId      = dummyTx.id
+
+    servers.foreach { server =>
+      Get(
+        s"/events/tx-script?txId=${txId.toHexString}",
+        server.port
+      ) check { response =>
+        val chainIndex = ChainIndex.from(blockHash, server.node.config.broker.groups)
+        val rightNode  = server.node.config.broker.chainIndexes.contains(chainIndex)
+
+        if (rightNode) {
+          response.code is StatusCode.Ok
+          val events = response.body.rightValue
+          events is s"""
+        |{
+        |  "chainFrom": ${chainIndex.from.value},
+        |  "chainTo": ${chainIndex.to.value},
+        |  "events": [
+        |    {
+        |      "type": "TxScriptEvent",
+        |      "blockHash": "${blockHash.toHexString}",
+        |      "txId": "${txId.toHexString}",
+        |      "eventIndex": 0,
+        |      "fields": [
+        |        {
+        |          "type": "U256",
+        |          "value": "4"
+        |        },
+        |        {
+        |          "type": "Address",
+        |          "value": "16BCZkZzGb3QnycJQefDHqeZcTA5RhrwYUDsAYkCf7RhS"
+        |        },
+        |        {
+        |          "type": "Address",
+        |          "value": "27gAhB8JB6UtE9tC3PwGRbXHiZJ9ApuCMoHqe1T4VzqFi"
+        |        }
+        |      ]
+        |    }
+        |  ]
+        |}
+        |""".stripMargin.filterNot(_.isWhitespace)
+        } else {
+          response.code is StatusCode.NotFound
+          val error = response.as[ApiError.NotFound]
+          error.detail is s"Transaction ${txId.toHexString} not found"
+        }
+      }
     }
   }
 }

--- a/app/src/test/scala/org/alephium/app/RestServerSpec.scala
+++ b/app/src/test/scala/org/alephium/app/RestServerSpec.scala
@@ -847,6 +847,24 @@ abstract class RestServerSpec(
       }
     }
   }
+
+  it should "get current events count for a contract" in {
+    val urlBase = s"/events/contract/current-count?contractAddress=$dummyContractAddress"
+
+    Get(urlBase).check { response =>
+      response.code is StatusCode.Ok
+      response.body.rightValue is "10"
+    }
+  }
+
+  it should "get current events count for a TxScript" in {
+    val urlBase = s"/events/tx-script/current-count?txId=${dummyTx.id.toHexString}"
+
+    Get(urlBase).check { response =>
+      response.code is StatusCode.Ok
+      response.body.rightValue is "10"
+    }
+  }
 }
 
 abstract class RestServerApiKeyDisableSpec(

--- a/app/src/test/scala/org/alephium/app/RestServerSpec.scala
+++ b/app/src/test/scala/org/alephium/app/RestServerSpec.scala
@@ -767,6 +767,12 @@ abstract class RestServerSpec(
         response.body.leftValue is s"""{"detail":"Invalid value (`end` must be smaller than ${start + CounterRange.MaxCounterRange})"}"""
     }
 
+    info("with start larger than (Int.MaxValue - MaxCounterRange)")
+    Get(s"$urlBase&start=${Int.MaxValue - CounterRange.MaxCounterRange + 1}").check { response =>
+      response.code is StatusCode.BadRequest
+      response.body.leftValue is s"""{"detail":"Invalid value (`start` must be smaller than ${Int.MaxValue - CounterRange.MaxCounterRange})"}"""
+    }
+
     def validResponse(response: Response[Either[String, String]]): Assertion = {
       response.code is StatusCode.Ok
       val events = response.body.rightValue
@@ -797,7 +803,7 @@ abstract class RestServerSpec(
         |      ]
         |    }
         |  ],
-        |  "nextCount": 2
+        |  "nextStart": 2
         |}
         |""".stripMargin.filterNot(_.isWhitespace)
     }
@@ -844,7 +850,7 @@ abstract class RestServerSpec(
         |      ]
         |    }
         |  ],
-        |  "nextCount": 2
+        |  "nextStart": 2
         |}
         |""".stripMargin.filterNot(_.isWhitespace)
         } else {

--- a/app/src/test/scala/org/alephium/app/RestServerSpec.scala
+++ b/app/src/test/scala/org/alephium/app/RestServerSpec.scala
@@ -123,7 +123,7 @@ abstract class RestServerSpec(
     }
     Get(s"/addresses/${dummyContractAddress}/group") check { response =>
       response.code is StatusCode.Ok
-      response.as[Group] is dummyContractGroup
+      response.as[Group] is Group(0)
     }
   }
 
@@ -373,10 +373,9 @@ abstract class RestServerSpec(
             response.code is StatusCode.Ok
             status is dummyTxStatus
           } else {
-            response.code is StatusCode.InternalServerError
-            response.as[ApiError.InternalServerError] is ApiError.InternalServerError(
-              s"${txId.toHexString} belongs to other groups"
-            )
+            val status = response.as[TxStatus]
+            response.code is StatusCode.Ok
+            status is TxNotFound
           }
         }
 

--- a/app/src/test/scala/org/alephium/app/RestServerSpec.scala
+++ b/app/src/test/scala/org/alephium/app/RestServerSpec.scala
@@ -754,10 +754,17 @@ abstract class RestServerSpec(
     info("with start only")
     Get(s"$urlBase&start=$start").check(validResponse)
 
-    info("with invalid start and end")
+    info("with start smaller than end")
     Get(s"$urlBase&start=$end&end=$start").check { response =>
       response.code is StatusCode.BadRequest
       response.body.leftValue is s"""{"detail":"Invalid value (`end` must be larger than `start`)"}"""
+    }
+
+    info("with end larger than (start + MaxCounterRange)")
+    Get(s"$urlBase&start=$start&end=${start + CounterRange.MaxCounterRange + 1}").check {
+      response =>
+        response.code is StatusCode.BadRequest
+        response.body.leftValue is s"""{"detail":"Invalid value (`end` must be smaller than ${start + CounterRange.MaxCounterRange})"}"""
     }
 
     def validResponse(response: Response[Either[String, String]]): Assertion = {

--- a/app/src/test/scala/org/alephium/app/ServerFixture.scala
+++ b/app/src/test/scala/org/alephium/app/ServerFixture.scala
@@ -356,23 +356,26 @@ object ServerFixture {
         eventKey: Hash,
         start: Int,
         endOpt: Option[Int]
-    )(isBlockInMainChain: BlockHash => Boolean): IOResult[AVector[LogStates]] = {
+    )(isBlockInMainChain: BlockHash => Boolean): IOResult[(Option[Int], AVector[LogStates])] = {
       lazy val address1 = Address.fromBase58("16BCZkZzGb3QnycJQefDHqeZcTA5RhrwYUDsAYkCf7RhS").get
       lazy val address2 = Address.fromBase58("27gAhB8JB6UtE9tC3PwGRbXHiZJ9ApuCMoHqe1T4VzqFi").get
 
       Right(
-        AVector(
-          LogStates(
-            block.hash,
-            eventKey,
-            states = AVector(
-              LogState(
-                txId = dummyTx.id,
-                index = 0,
-                fields = AVector(
-                  vm.Val.U256(U256.unsafe(4)),
-                  vm.Val.Address(address1.lockupScript),
-                  vm.Val.Address(address2.lockupScript)
+        (
+          Some(2),
+          AVector(
+            LogStates(
+              block.hash,
+              eventKey,
+              states = AVector(
+                LogState(
+                  txId = dummyTx.id,
+                  index = 0,
+                  fields = AVector(
+                    vm.Val.U256(U256.unsafe(4)),
+                    vm.Val.Address(address1.lockupScript),
+                    vm.Val.Address(address2.lockupScript)
+                  )
                 )
               )
             )

--- a/app/src/test/scala/org/alephium/app/ServerFixture.scala
+++ b/app/src/test/scala/org/alephium/app/ServerFixture.scala
@@ -355,7 +355,7 @@ object ServerFixture {
         chainIndex: ChainIndex,
         eventKey: Hash,
         start: Int,
-        endOpt: Option[Int]
+        end: Int = start + CounterRange.MaxCounterRange
     )(isBlockInMainChain: BlockHash => Boolean): IOResult[(Option[Int], AVector[LogStates])] = {
       lazy val address1 = Address.fromBase58("16BCZkZzGb3QnycJQefDHqeZcTA5RhrwYUDsAYkCf7RhS").get
       lazy val address2 = Address.fromBase58("27gAhB8JB6UtE9tC3PwGRbXHiZJ9ApuCMoHqe1T4VzqFi").get

--- a/app/src/test/scala/org/alephium/app/ServerFixture.scala
+++ b/app/src/test/scala/org/alephium/app/ServerFixture.scala
@@ -327,13 +327,19 @@ object ServerFixture {
     }
 
     override def getEvents(
-        blockHash: BlockHash,
-        eventKey: Hash
+        chainIndex: ChainIndex,
+        eventKey: Hash,
+        start: Int,
+        endOpt: Option[Int]
     ): IOResult[Option[LogStates]] = {
       lazy val address1 = Address.fromBase58("16BCZkZzGb3QnycJQefDHqeZcTA5RhrwYUDsAYkCf7RhS").get
       lazy val address2 = Address.fromBase58("27gAhB8JB6UtE9tC3PwGRbXHiZJ9ApuCMoHqe1T4VzqFi").get
       lazy val txId = Hash
         .from(Hex.unsafe("503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69"))
+        .get
+      // FIXME: tests are feeding block here, but it is hardcoded here
+      lazy val blockHash = BlockHash
+        .from(Hex.unsafe("bdaf9dc514ce7d34b6474b8ca10a3dfb93ba997cb9d5ff1ea724ebe2af48abe5"))
         .get
 
       Right(

--- a/app/src/test/scala/org/alephium/app/ServerFixture.scala
+++ b/app/src/test/scala/org/alephium/app/ServerFixture.scala
@@ -355,8 +355,8 @@ object ServerFixture {
         chainIndex: ChainIndex,
         eventKey: Hash,
         start: Int,
-        end: Int = start + CounterRange.MaxCounterRange
-    )(isBlockInMainChain: BlockHash => Boolean): IOResult[(Option[Int], AVector[LogStates])] = {
+        end: Int
+    ): IOResult[(Option[Int], AVector[LogStates])] = {
       lazy val address1 = Address.fromBase58("16BCZkZzGb3QnycJQefDHqeZcTA5RhrwYUDsAYkCf7RhS").get
       lazy val address2 = Address.fromBase58("27gAhB8JB6UtE9tC3PwGRbXHiZJ9ApuCMoHqe1T4VzqFi").get
 

--- a/app/src/test/scala/org/alephium/app/ServerFixture.scala
+++ b/app/src/test/scala/org/alephium/app/ServerFixture.scala
@@ -381,6 +381,13 @@ object ServerFixture {
       )
     }
 
+    override def getEventsCurrentCount(
+        chainIndex: ChainIndex,
+        eventKey: Hash
+    ): IOResult[Option[Int]] = {
+      Right(Some(10))
+    }
+
     // scalastyle:off no.equal
     override def getBestCachedWorldState(groupIndex: GroupIndex): IOResult[WorldState.Cached] = {
       val contractGroup = brokerConfig.groups - 1

--- a/app/src/test/scala/org/alephium/app/ServerFixture.scala
+++ b/app/src/test/scala/org/alephium/app/ServerFixture.scala
@@ -356,7 +356,7 @@ object ServerFixture {
         eventKey: Hash,
         start: Int,
         endOpt: Option[Int]
-    ): IOResult[AVector[LogStates]] = {
+    )(isBlockInMainChain: BlockHash => Boolean): IOResult[AVector[LogStates]] = {
       lazy val address1 = Address.fromBase58("16BCZkZzGb3QnycJQefDHqeZcTA5RhrwYUDsAYkCf7RhS").get
       lazy val address2 = Address.fromBase58("27gAhB8JB6UtE9tC3PwGRbXHiZJ9ApuCMoHqe1T4VzqFi").get
 

--- a/app/src/test/scala/org/alephium/app/ServerFixture.scala
+++ b/app/src/test/scala/org/alephium/app/ServerFixture.scala
@@ -356,13 +356,13 @@ object ServerFixture {
         eventKey: Hash,
         start: Int,
         end: Int
-    ): IOResult[(Option[Int], AVector[LogStates])] = {
+    ): IOResult[(Int, AVector[LogStates])] = {
       lazy val address1 = Address.fromBase58("16BCZkZzGb3QnycJQefDHqeZcTA5RhrwYUDsAYkCf7RhS").get
       lazy val address2 = Address.fromBase58("27gAhB8JB6UtE9tC3PwGRbXHiZJ9ApuCMoHqe1T4VzqFi").get
 
       Right(
         (
-          Some(2),
+          2,
           AVector(
             LogStates(
               block.hash,

--- a/flow/src/main/scala/org/alephium/flow/core/BlockFlowState.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/BlockFlowState.scala
@@ -519,10 +519,14 @@ object BlockFlowState {
     }
   }
 
-  final case class TxStatus(
+  sealed trait TxStatus
+
+  final case class Confirmed(
       index: TxIndex,
       chainConfirmations: Int,
       fromGroupConfirmations: Int,
       toGroupConfirmations: Int
-  )
+  ) extends TxStatus
+
+  final case object MemPooled extends TxStatus
 }

--- a/flow/src/main/scala/org/alephium/flow/core/ContractUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/ContractUtils.scala
@@ -1,0 +1,49 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.flow.core
+
+import org.alephium.protocol.model.ContractId
+import org.alephium.protocol.model.GroupIndex
+
+trait ContractUtils { Self: FlowUtils =>
+  def getGroupForContract(contractId: ContractId): Either[String, GroupIndex] = {
+    val failure: Either[String, GroupIndex] = Left("Group not found.").withRight[GroupIndex]
+    brokerConfig.groupRange.foldLeft(failure) { case (prevResult, currentGroup: Int) =>
+      prevResult match {
+        case Right(prevResult) => Right(prevResult)
+        case Left(_) =>
+          getContractGroup(contractId, GroupIndex.unsafe(currentGroup))
+      }
+    }
+  }
+
+  def getContractGroup(
+      contractId: ContractId,
+      groupIndex: GroupIndex
+  ): Either[String, GroupIndex] = {
+    val searchResult = for {
+      worldState <- getBestPersistedWorldState(groupIndex)
+      existed    <- worldState.contractState.exists(contractId)
+    } yield existed
+
+    searchResult match {
+      case Right(true)  => Right(groupIndex)
+      case Right(false) => Left("Group not found. Please check another broker")
+      case Left(error)  => Left(s"Failed in IO: $error")
+    }
+  }
+}

--- a/flow/src/main/scala/org/alephium/flow/core/FlowUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/FlowUtils.scala
@@ -40,6 +40,7 @@ trait FlowUtils
     with SyncUtils
     with TxUtils
     with LogUtils
+    with ContractUtils
     with ConflictedBlocks
     with LazyLogging { Self: BlockFlow =>
   implicit def mempoolSetting: MemPoolSetting

--- a/flow/src/main/scala/org/alephium/flow/core/LogUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/LogUtils.scala
@@ -32,7 +32,7 @@ trait LogUtils { Self: FlowUtils =>
       eventKey: Hash,
       start: Int,
       end: Int
-  ): IOResult[(Option[Int], AVector[LogStates])] = {
+  ): IOResult[(Int, AVector[LogStates])] = {
     var allLogStates: ArrayBuffer[LogStates] = ArrayBuffer.empty
     var nextCount                            = start
 
@@ -62,8 +62,7 @@ trait LogUtils { Self: FlowUtils =>
       worldState <- blockFlow.getBestPersistedWorldState(chainIndex.from)
       _          <- rec(worldState, LogStatesId(eventKey, nextCount))
     } yield {
-      val nextCountOpt = if (end < nextCount) Some(nextCount) else None
-      (nextCountOpt, AVector.from(allLogStates))
+      (nextCount, AVector.from(allLogStates))
     }
   }
 

--- a/flow/src/main/scala/org/alephium/flow/core/LogUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/LogUtils.scala
@@ -66,4 +66,14 @@ trait LogUtils { Self: FlowUtils =>
       _          <- rec(worldState, LogStatesId(eventKey, start))
     } yield AVector.from(allLogStates)
   }
+
+  def getEventsCurrentCount(
+      chainIndex: ChainIndex,
+      eventKey: Hash
+  ): IOResult[Option[Int]] = {
+    for {
+      worldState <- blockFlow.getBestPersistedWorldState(chainIndex.from)
+      count      <- worldState.logCounterState.getOpt(eventKey)
+    } yield count
+  }
 }

--- a/flow/src/main/scala/org/alephium/flow/core/LogUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/LogUtils.scala
@@ -51,13 +51,8 @@ trait LogUtils { Self: FlowUtils =>
       worldState.logState.getOpt(logStatesId) match {
         case Right(Some(logStates)) =>
           assume(logStates.states.nonEmpty)
-          val newCounter = logStatesId.counter + logStates.states.length
+          val newCounter = logStatesId.counter + 1
           if (end < newCounter) {
-            appendLogStates(
-              logStates.copy(
-                states = logStates.states.take(end - logStatesId.counter)
-              )
-            )
             Right(())
           } else {
             appendLogStates(logStates)

--- a/flow/src/main/scala/org/alephium/flow/core/LogUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/LogUtils.scala
@@ -31,10 +31,8 @@ trait LogUtils { Self: FlowUtils =>
       chainIndex: ChainIndex,
       eventKey: Hash,
       start: Int,
-      endOpt: Option[Int]
+      end: Int
   )(isBlockInMainChain: BlockHash => Boolean): IOResult[(Option[Int], AVector[LogStates])] = {
-    val end = endOpt.getOrElse(Int.MaxValue)
-
     var allLogStates: ArrayBuffer[LogStates] = ArrayBuffer.empty
     var nextCount                            = start
 

--- a/flow/src/main/scala/org/alephium/flow/core/LogUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/LogUtils.scala
@@ -20,7 +20,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 
 import org.alephium.io.IOResult
-import org.alephium.protocol.{BlockHash, Hash}
+import org.alephium.protocol.Hash
 import org.alephium.protocol.model.ChainIndex
 import org.alephium.protocol.vm.{LogStates, LogStatesId, WorldState}
 import org.alephium.util.AVector
@@ -32,15 +32,9 @@ trait LogUtils { Self: FlowUtils =>
       eventKey: Hash,
       start: Int,
       end: Int
-  )(isBlockInMainChain: BlockHash => Boolean): IOResult[(Option[Int], AVector[LogStates])] = {
+  ): IOResult[(Option[Int], AVector[LogStates])] = {
     var allLogStates: ArrayBuffer[LogStates] = ArrayBuffer.empty
     var nextCount                            = start
-
-    def appendLogStates(logStates: LogStates): Unit = {
-      if (isBlockInMainChain(logStates.blockHash)) {
-        allLogStates = allLogStates :+ logStates
-      }
-    }
 
     @tailrec
     def rec(
@@ -54,7 +48,7 @@ trait LogUtils { Self: FlowUtils =>
           if (end < nextCount) {
             Right(())
           } else {
-            appendLogStates(logStates)
+            allLogStates = allLogStates :+ logStates
             rec(worldState, LogStatesId(eventKey, nextCount))
           }
         case Right(None) =>

--- a/flow/src/main/scala/org/alephium/flow/core/LogUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/LogUtils.scala
@@ -17,15 +17,22 @@
 package org.alephium.flow.core
 
 import org.alephium.io.IOResult
-import org.alephium.protocol.{BlockHash, Hash}
+import org.alephium.protocol.Hash
 import org.alephium.protocol.model.ChainIndex
 import org.alephium.protocol.vm.LogStates
 import org.alephium.protocol.vm.LogStatesId
 
 trait LogUtils { Self: FlowUtils =>
-  def getEvents(blockHash: BlockHash, eventKey: Hash): IOResult[Option[LogStates]] = {
-    val chainIndex  = ChainIndex.from(blockHash)
-    val logStatesId = LogStatesId(blockHash, eventKey)
+
+  def getEvents(
+      chainIndex: ChainIndex,
+      eventKey: Hash,
+      start: Int,
+      endOpt: Option[Int]
+  ): IOResult[Option[LogStates]] = {
+    logger.info(s"$endOpt")
+
+    val logStatesId = LogStatesId(eventKey, start)
 
     for {
       worldState   <- blockFlow.getBestPersistedWorldState(chainIndex.from)

--- a/flow/src/main/scala/org/alephium/flow/core/TxUtils.scala
+++ b/flow/src/main/scala/org/alephium/flow/core/TxUtils.scala
@@ -20,7 +20,7 @@ import scala.annotation.tailrec
 
 import TxUtils._
 
-import org.alephium.flow.core.BlockFlowState.{BlockCache, TxStatus}
+import org.alephium.flow.core.BlockFlowState.{BlockCache, Confirmed, MemPooled, TxStatus}
 import org.alephium.flow.core.FlowUtils._
 import org.alephium.flow.core.UtxoSelectionAlgo.{AssetAmounts, ProvidedGas}
 import org.alephium.flow.gasestimation._
@@ -305,7 +305,7 @@ trait TxUtils { Self: FlowUtils =>
       chain.getTxStatusUnsafe(txId).flatMap { chainStatus =>
         val confirmations = chainStatus.confirmations
         if (chainIndex.isIntraGroup) {
-          Some(TxStatus(chainStatus.index, confirmations, confirmations, confirmations))
+          Some(Confirmed(chainStatus.index, confirmations, confirmations, confirmations))
         } else {
           val confirmHash = chainStatus.index.hash
           val fromGroupConfirmations =
@@ -313,7 +313,12 @@ trait TxUtils { Self: FlowUtils =>
           val toGroupConfirmations =
             getToGroupConfirmationsUnsafe(confirmHash, chainIndex)
           Some(
-            TxStatus(chainStatus.index, confirmations, fromGroupConfirmations, toGroupConfirmations)
+            Confirmed(
+              chainStatus.index,
+              confirmations,
+              fromGroupConfirmations,
+              toGroupConfirmations
+            )
           )
         }
       }
@@ -389,6 +394,58 @@ trait TxUtils { Self: FlowUtils =>
       groupView <- getImmutableGroupView(groupIndex)
       failedTxs <- txs.filterE(tx => groupView.getPreOutputs(tx.unsigned.inputs).map(_.isEmpty))
     } yield failedTxs
+  }
+
+  def searchLocalTransactionStatus(
+      txId: Hash,
+      chainIndexes: AVector[ChainIndex]
+  ): Either[String, Option[TxStatus]] = {
+    @tailrec
+    def rec(
+        indexes: AVector[ChainIndex],
+        currentRes: Either[String, Option[TxStatus]]
+    ): Either[String, Option[TxStatus]] = {
+      if (indexes.isEmpty) {
+        currentRes
+      } else {
+        val index = indexes.head
+        val res   = getTransactionStatus(txId, index)
+        res match {
+          case Right(None) => rec(indexes.tail, res)
+          case Right(_)    => res
+          case Left(_)     => res
+        }
+      }
+    }
+    rec(chainIndexes, Right(None))
+  }
+
+  def getTransactionStatus(
+      txId: Hash,
+      chainIndex: ChainIndex
+  ): Either[String, Option[TxStatus]] = {
+    for {
+      _ <- checkTxChainIndex(chainIndex, txId)
+      status <- getTxStatus(txId, chainIndex)
+        .map {
+          case Some(status) => Some(status)
+          case None         => if (isInMemPool(txId, chainIndex)) Some(MemPooled) else None
+        }
+        .left
+        .map(_.toString)
+    } yield status
+  }
+
+  def isInMemPool(txId: Hash, chainIndex: ChainIndex): Boolean = {
+    Self.blockFlow.getMemPool(chainIndex).contains(chainIndex, txId)
+  }
+
+  def checkTxChainIndex(chainIndex: ChainIndex, tx: Hash): Either[String, Unit] = {
+    if (brokerConfig.contains(chainIndex.from)) {
+      Right(())
+    } else {
+      Left(s"${tx.toHexString} belongs to other groups")
+    }
   }
 
   private def checkProvidedGas(gasOpt: Option[GasBox], gasPrice: GasPrice): Either[String, Unit] = {

--- a/flow/src/main/scala/org/alephium/flow/io/Storages.scala
+++ b/flow/src/main/scala/org/alephium/flow/io/Storages.scala
@@ -48,11 +48,13 @@ object Storages {
     val nodeStateStorage  = NodeStateRockDBStorage(db, All, writeOptions)
     val trieStorage       = RocksDBKeyValueStorage[Hash, Node](db, Trie, writeOptions)
     val logStorage        = RocksDBKeyValueStorage[LogStatesId, LogStates](db, Log, writeOptions)
-    val worldStateStorage = WorldStateRockDBStorage(trieStorage, logStorage, db, All, writeOptions)
-    val emptyWorldState   = WorldState.emptyPersisted(trieStorage, logStorage)
-    val pendingTxStorage  = PendingTxRocksDBStorage(db, PendingTx, writeOptions)
-    val readyTxStorage    = ReadyTxRocksDBStorage(db, ReadyTx, writeOptions)
-    val brokerStorage     = BrokerRocksDBStorage(db, Broker, writeOptions)
+    val logCounterStorage = RocksDBKeyValueStorage[Hash, Int](db, LogCounter, writeOptions)
+    val worldStateStorage =
+      WorldStateRockDBStorage(trieStorage, logStorage, logCounterStorage, db, All, writeOptions)
+    val emptyWorldState  = WorldState.emptyPersisted(trieStorage, logStorage, logCounterStorage)
+    val pendingTxStorage = PendingTxRocksDBStorage(db, PendingTx, writeOptions)
+    val readyTxStorage   = ReadyTxRocksDBStorage(db, ReadyTx, writeOptions)
+    val brokerStorage    = BrokerRocksDBStorage(db, Broker, writeOptions)
 
     Storages(
       AVector(db),

--- a/flow/src/test/scala/org/alephium/flow/core/BlockFlowSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/core/BlockFlowSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 
 import org.alephium.flow.FlowFixture
 import org.alephium.flow.core.BlockChain.TxIndex
-import org.alephium.flow.core.BlockFlowState.{BlockCache, TxStatus}
+import org.alephium.flow.core.BlockFlowState.{BlockCache, Confirmed}
 import org.alephium.flow.io.StoragesFixture
 import org.alephium.flow.setting.AlephiumConfigFixture
 import org.alephium.protocol.{ALPH, BlockHash, Generators}
@@ -744,7 +744,7 @@ class BlockFlowSpec extends AlephiumSpec {
         block.transactions.foreachWithIndex { case (tx, index) =>
           from is to
           blockFlow.getTxStatus(tx.id, ChainIndex.unsafe(from, to)) isE
-            Some(TxStatus(TxIndex(block.hash, index), 1, 1, 1))
+            Some(Confirmed(TxIndex(block.hash, index), 1, 1, 1))
         }
       }
     }
@@ -774,7 +774,7 @@ class BlockFlowSpec extends AlephiumSpec {
             count(newIndexes0.contains(ChainIndex.unsafe(to, to)))
           blockFlow.getTxStatus(tx.id, ChainIndex.unsafe(from, to)) isE
             Some(
-              TxStatus(
+              Confirmed(
                 TxIndex(block.hash, index),
                 chainConfirmations,
                 fromConfirmations,
@@ -790,7 +790,7 @@ class BlockFlowSpec extends AlephiumSpec {
       blocks.foreachWithIndex { case (block, to) =>
         block.transactions.foreachWithIndex { case (tx, index) =>
           blockFlow.getTxStatus(tx.id, ChainIndex.unsafe(from, to)) isE
-            Some(TxStatus(TxIndex(block.hash, index), 2, 2, 2))
+            Some(Confirmed(TxIndex(block.hash, index), 2, 2, 2))
         }
       }
     }
@@ -809,7 +809,7 @@ class BlockFlowSpec extends AlephiumSpec {
 
       addAndCheck(blockFlow0, block)
       blockFlow0.getTxStatus(block.transactions.head.id, chainIndex) isE
-        Some(TxStatus(TxIndex(block.hash, 0), 1, 1, 1))
+        Some(Confirmed(TxIndex(block.hash, 0), 1, 1, 1))
     }
   }
 
@@ -828,17 +828,17 @@ class BlockFlowSpec extends AlephiumSpec {
 
       addAndCheck(blockFlow0, block0)
       blockFlow0.getTxStatus(block0.transactions.head.id, chainIndex) isE
-        Some(TxStatus(TxIndex(block0.hash, 0), 1, 0, 0))
+        Some(Confirmed(TxIndex(block0.hash, 0), 1, 0, 0))
 
       val block1 = emptyBlock(blockFlow0, ChainIndex.unsafe(from, from))
       addAndCheck(blockFlow0, block1)
       blockFlow0.getTxStatus(block0.transactions.head.id, chainIndex) isE
-        Some(TxStatus(TxIndex(block0.hash, 0), 1, 1, 0))
+        Some(Confirmed(TxIndex(block0.hash, 0), 1, 1, 0))
 
       val block2 = emptyBlock(blockFlow0, ChainIndex.unsafe(to, to))
       addAndCheck(blockFlow0, block2)
       blockFlow0.getTxStatus(block0.transactions.head.id, chainIndex) isE
-        Some(TxStatus(TxIndex(block0.hash, 0), 1, 1, 1))
+        Some(Confirmed(TxIndex(block0.hash, 0), 1, 1, 1))
     }
   }
 

--- a/flow/src/test/scala/org/alephium/flow/core/VMSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/core/VMSpec.scala
@@ -25,7 +25,7 @@ import org.alephium.crypto.{ED25519, ED25519Signature, SecP256K1, SecP256K1Signa
 import org.alephium.flow.FlowFixture
 import org.alephium.flow.mempool.MemPool.AddedToSharedPool
 import org.alephium.flow.validation.{TxScriptExeFailed, TxValidation}
-import org.alephium.protocol.{ALPH, BlockHash, Hash}
+import org.alephium.protocol.{ALPH, Hash}
 import org.alephium.protocol.model._
 import org.alephium.protocol.vm._
 import org.alephium.protocol.vm.lang.Compiler
@@ -1384,7 +1384,7 @@ class VMSpec extends AlephiumSpec {
     {
       info("All events emitted from the contract after the first method call")
 
-      val (nextCount, allLogStates) = getEvents(blockFlow, chainIndex, contractId, 0, None)
+      val (nextCount, allLogStates) = getEvents(blockFlow, chainIndex, contractId, 0)
       nextCount is None
       allLogStates.length is 1
       val logStates = allLogStates.head
@@ -1398,12 +1398,12 @@ class VMSpec extends AlephiumSpec {
     {
       info("All events emitted from the contract after the second method call")
 
-      val (nextCount1, _) = getEvents(blockFlow, chainIndex, contractId, 0, Some(1))
+      val (nextCount1, _) = getEvents(blockFlow, chainIndex, contractId, 0, 1)
       nextCount1.value is 2
-      val (nextCount2, _) = getEvents(blockFlow, chainIndex, contractId, 0, Some(2))
+      val (nextCount2, _) = getEvents(blockFlow, chainIndex, contractId, 0, 2)
       nextCount2 is None
 
-      val (nextCount, allLogStates) = getEvents(blockFlow, chainIndex, contractId, 0, None)
+      val (nextCount, allLogStates) = getEvents(blockFlow, chainIndex, contractId, 0)
       nextCount is None
       allLogStates.length is 2
       val logStates1 = allLogStates.head
@@ -1415,7 +1415,7 @@ class VMSpec extends AlephiumSpec {
 
     {
       info("Part of the events emitted from the contract after the second method call")
-      val (nextCount, allLogStates) = getEvents(blockFlow, chainIndex, contractId, 0, Some(2))
+      val (nextCount, allLogStates) = getEvents(blockFlow, chainIndex, contractId, 0, 2)
       nextCount is None
       allLogStates.length is 2
 
@@ -1434,12 +1434,6 @@ class VMSpec extends AlephiumSpec {
       addingLogState.fields.length is 2
       addingLogState.fields(0) is Val.U256(U256.unsafe(4))
       addingLogState.fields(1) is Val.U256(U256.unsafe(14))
-    }
-
-    {
-      info("If events are from blocks that are not part of the main chain")
-      getEvents(blockFlow, chainIndex, contractId, 0, None, _ => false)._2.length is 0
-      getEvents(blockFlow, chainIndex, contractId, 0, Some(3), _ => false)._2.length is 0
     }
   }
 
@@ -1479,10 +1473,9 @@ class VMSpec extends AlephiumSpec {
       chainIndex: ChainIndex,
       contractId: ContractId,
       start: Int,
-      endOpt: Option[Int],
-      isBlockInMainChain: BlockHash => Boolean = _ => true
+      end: Int = Int.MaxValue
   ): (Option[Int], AVector[LogStates]) = {
-    blockFlow.getEvents(chainIndex, contractId, start, endOpt)(isBlockInMainChain).rightValue
+    blockFlow.getEvents(chainIndex, contractId, start, end).rightValue
   }
 
   private def getCurentCount(

--- a/flow/src/test/scala/org/alephium/flow/core/VMSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/core/VMSpec.scala
@@ -1201,6 +1201,8 @@ class VMSpec extends AlephiumSpec {
       logStates.eventKey is contractId
       logStates.states.length is 2
 
+      getCurentCount(blockFlow, chainIndex.from, contractId).value is 2
+
       val addingLogState = logStates.states(0)
       addingLogState.txId is callingBlock.nonCoinbase.head.id
       addingLogState.index is 0.toByte
@@ -1225,6 +1227,8 @@ class VMSpec extends AlephiumSpec {
       logStates.blockHash is createContractBlock.hash
       logStates.eventKey is createContractTxId
       logStates.states.length is 1
+
+      getCurentCount(blockFlow, chainIndex.from, createContractTxId).value is 1
 
       val createContractLogState = logStates.states(0)
       createContractLogState.txId is createContractBlock.nonCoinbase.head.id
@@ -1258,6 +1262,8 @@ class VMSpec extends AlephiumSpec {
       logStates.blockHash is destroyContractBlock.hash
       logStates.eventKey is destroyContractTxId
       logStates.states.length is 1
+
+      getCurentCount(blockFlow, chainIndex.from, destroyContractTxId).value is 1
 
       val destroyContractLogState = logStates.states(0)
       destroyContractLogState.txId is destroyContractBlock.nonCoinbase.head.id
@@ -1345,6 +1351,8 @@ class VMSpec extends AlephiumSpec {
     logStates.eventKey is contractId
     logStates.states.length is 2
 
+    getCurentCount(blockFlow, chainIndex.from, contractId).value is 2
+
     val testEventLogState1 = logStates.states(0)
     testEventLogState1.txId is callingBlock.nonCoinbase.head.id
     testEventLogState1.index is 0.toByte
@@ -1382,18 +1390,28 @@ class VMSpec extends AlephiumSpec {
     )
   }
 
-  // FIXME: fix all the counter set to 0
   private def getLogStates(
       blockFlow: BlockFlow,
       groupIndex: GroupIndex,
-      counter: Int,
+      count: Int,
       contractId: ContractId
   ): Option[LogStates] = {
-    val logStatesId = LogStatesId(contractId, counter)
+    val logStatesId = LogStatesId(contractId, count)
     (for {
       worldState   <- blockFlow.getBestPersistedWorldState(groupIndex)
       logStatesOpt <- worldState.logState.getOpt(logStatesId)
     } yield logStatesOpt).rightValue
+  }
+
+  private def getCurentCount(
+      blockFlow: BlockFlow,
+      groupIndex: GroupIndex,
+      contractId: ContractId
+  ): Option[Int] = {
+    (for {
+      worldState <- blockFlow.getBestPersistedWorldState(groupIndex)
+      countOpt   <- worldState.logCounterState.getOpt(contractId)
+    } yield countOpt).rightValue
   }
 }
 // scalastyle:on file.size.limit no.equal regex

--- a/flow/src/test/scala/org/alephium/flow/core/VMSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/core/VMSpec.scala
@@ -1221,7 +1221,7 @@ class VMSpec extends AlephiumSpec {
       val logStatesOpt = getLogStates(blockFlow, chainIndex.from, contractId, 0)
       val logStates    = logStatesOpt.value
 
-      verifyCallingEvents(logStates, callingBlock, result = 10, currentCount = 2)
+      verifyCallingEvents(logStates, callingBlock, result = 10, currentCount = 1)
     }
 
     {
@@ -1359,7 +1359,7 @@ class VMSpec extends AlephiumSpec {
     logStates.eventKey is contractId
     logStates.states.length is 2
 
-    getCurentCount(blockFlow, chainIndex.from, contractId).value is 2
+    getCurentCount(blockFlow, chainIndex.from, contractId).value is 1
 
     val testEventLogState1 = logStates.states(0)
     testEventLogState1.txId is callingBlock.nonCoinbase.head.id
@@ -1388,7 +1388,7 @@ class VMSpec extends AlephiumSpec {
       allLogStates.length is 1
       val logStates = allLogStates.head
 
-      verifyCallingEvents(logStates, callingBlock, result = 10, currentCount = 2)
+      verifyCallingEvents(logStates, callingBlock, result = 10, currentCount = 1)
     }
 
     val secondCallingBlock = simpleScript(blockFlow, chainIndex, callingScript)
@@ -1402,23 +1402,23 @@ class VMSpec extends AlephiumSpec {
       val logStates1 = allLogStates.head
       val logStates2 = allLogStates.last
 
-      verifyCallingEvents(logStates1, callingBlock, result = 10, currentCount = 4)
-      verifyCallingEvents(logStates2, secondCallingBlock, result = 14, currentCount = 4)
+      verifyCallingEvents(logStates1, callingBlock, result = 10, currentCount = 2)
+      verifyCallingEvents(logStates2, secondCallingBlock, result = 14, currentCount = 2)
     }
 
     {
       info("Part of the events emitted from the contract after the second method call")
-      val allLogStates = getEvents(blockFlow, chainIndex, contractId, 0, Some(3))
+      val allLogStates = getEvents(blockFlow, chainIndex, contractId, 0, Some(2))
       allLogStates.length is 2
 
       val logStates1 = allLogStates.head
       val logStates2 = allLogStates.last
 
-      verifyCallingEvents(logStates1, callingBlock, result = 10, currentCount = 4)
+      verifyCallingEvents(logStates1, callingBlock, result = 10, currentCount = 2)
 
       logStates2.blockHash is secondCallingBlock.hash
       logStates2.eventKey is contractId
-      logStates2.states.length is 1
+      logStates2.states.length is 2
 
       val addingLogState = logStates2.states(0)
       addingLogState.txId is secondCallingBlock.nonCoinbase.head.id

--- a/flow/src/test/scala/org/alephium/flow/core/VMSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/core/VMSpec.scala
@@ -1385,7 +1385,7 @@ class VMSpec extends AlephiumSpec {
       info("All events emitted from the contract after the first method call")
 
       val (nextCount, allLogStates) = getEvents(blockFlow, chainIndex, contractId, 0)
-      nextCount is None
+      nextCount is 1
       allLogStates.length is 1
       val logStates = allLogStates.head
 
@@ -1401,10 +1401,10 @@ class VMSpec extends AlephiumSpec {
       val (nextCount1, _) = getEvents(blockFlow, chainIndex, contractId, 0, 1)
       nextCount1.value is 2
       val (nextCount2, _) = getEvents(blockFlow, chainIndex, contractId, 0, 2)
-      nextCount2 is None
+      nextCount2 is 2
 
       val (nextCount, allLogStates) = getEvents(blockFlow, chainIndex, contractId, 0)
-      nextCount is None
+      nextCount is 2
       allLogStates.length is 2
       val logStates1 = allLogStates.head
       val logStates2 = allLogStates.last
@@ -1416,7 +1416,7 @@ class VMSpec extends AlephiumSpec {
     {
       info("Part of the events emitted from the contract after the second method call")
       val (nextCount, allLogStates) = getEvents(blockFlow, chainIndex, contractId, 0, 2)
-      nextCount is None
+      nextCount is 2
       allLogStates.length is 2
 
       val logStates1 = allLogStates.head
@@ -1474,7 +1474,7 @@ class VMSpec extends AlephiumSpec {
       contractId: ContractId,
       start: Int,
       end: Int = Int.MaxValue
-  ): (Option[Int], AVector[LogStates]) = {
+  ): (Int, AVector[LogStates]) = {
     blockFlow.getEvents(chainIndex, contractId, start, end).rightValue
   }
 

--- a/flow/src/test/scala/org/alephium/flow/core/VMSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/core/VMSpec.scala
@@ -1384,7 +1384,8 @@ class VMSpec extends AlephiumSpec {
     {
       info("All events emitted from the contract after the first method call")
 
-      val allLogStates = getEvents(blockFlow, chainIndex, contractId, 0, None)
+      val (nextCount, allLogStates) = getEvents(blockFlow, chainIndex, contractId, 0, None)
+      nextCount is None
       allLogStates.length is 1
       val logStates = allLogStates.head
 
@@ -1397,7 +1398,13 @@ class VMSpec extends AlephiumSpec {
     {
       info("All events emitted from the contract after the second method call")
 
-      val allLogStates = getEvents(blockFlow, chainIndex, contractId, 0, None)
+      val (nextCount1, _) = getEvents(blockFlow, chainIndex, contractId, 0, Some(1))
+      nextCount1.value is 2
+      val (nextCount2, _) = getEvents(blockFlow, chainIndex, contractId, 0, Some(2))
+      nextCount2 is None
+
+      val (nextCount, allLogStates) = getEvents(blockFlow, chainIndex, contractId, 0, None)
+      nextCount is None
       allLogStates.length is 2
       val logStates1 = allLogStates.head
       val logStates2 = allLogStates.last
@@ -1408,7 +1415,8 @@ class VMSpec extends AlephiumSpec {
 
     {
       info("Part of the events emitted from the contract after the second method call")
-      val allLogStates = getEvents(blockFlow, chainIndex, contractId, 0, Some(2))
+      val (nextCount, allLogStates) = getEvents(blockFlow, chainIndex, contractId, 0, Some(2))
+      nextCount is None
       allLogStates.length is 2
 
       val logStates1 = allLogStates.head
@@ -1430,8 +1438,8 @@ class VMSpec extends AlephiumSpec {
 
     {
       info("If events are from blocks that are not part of the main chain")
-      getEvents(blockFlow, chainIndex, contractId, 0, None, _ => false).length is 0
-      getEvents(blockFlow, chainIndex, contractId, 0, Some(3), _ => false).length is 0
+      getEvents(blockFlow, chainIndex, contractId, 0, None, _ => false)._2.length is 0
+      getEvents(blockFlow, chainIndex, contractId, 0, Some(3), _ => false)._2.length is 0
     }
   }
 
@@ -1473,7 +1481,7 @@ class VMSpec extends AlephiumSpec {
       start: Int,
       endOpt: Option[Int],
       isBlockInMainChain: BlockHash => Boolean = _ => true
-  ): AVector[LogStates] = {
+  ): (Option[Int], AVector[LogStates]) = {
     blockFlow.getEvents(chainIndex, contractId, start, endOpt)(isBlockInMainChain).rightValue
   }
 

--- a/flow/src/test/scala/org/alephium/flow/core/VMSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/core/VMSpec.scala
@@ -1267,17 +1267,25 @@ class VMSpec extends AlephiumSpec {
     }
 
     {
-      info("Events emitted from the contract does not exist in the block")
+      info("Events emitted from the contract with wrong counter")
 
-//      val wrongBlockId = BlockHash.generate
-      val logStatesOpt1 =
-        getLogStates(blockFlow, chainIndex.from, 0, contractId)
-      logStatesOpt1 is None
+      val logStatesOpt1 = getLogStates(blockFlow, chainIndex.from, 0, contractId)
+      val logStates1    = logStatesOpt1.value
+      val newCounter    = logStates1.states.length
+
+      newCounter is 2
+
+      AVector(1, 2, 100).foreach { counter =>
+        getLogStates(blockFlow, chainIndex.from, counter, contractId) is None
+      }
+    }
+
+    {
+      info("Events emitted from a non-existent contract")
 
       val wrongContractId = Hash.generate
-      val logStatesOpt2 =
-        getLogStates(blockFlow, chainIndex.from, 0, wrongContractId)
-      logStatesOpt2 is None
+      val logStatesOpt    = getLogStates(blockFlow, chainIndex.from, 0, wrongContractId)
+      logStatesOpt is None
     }
   }
 

--- a/flow/src/test/scala/org/alephium/flow/handler/TxHandlerSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/handler/TxHandlerSpec.scala
@@ -22,6 +22,7 @@ import org.scalacheck.Gen
 import org.scalatest.concurrent.Eventually.eventually
 
 import org.alephium.flow.{AlephiumFlowActorSpec, FlowFixture}
+import org.alephium.flow.core.BlockFlowState
 import org.alephium.flow.model.{PersistedTxId, ReadyTxInfo}
 import org.alephium.flow.network.InterCliqueManager
 import org.alephium.flow.network.broker.BrokerHandler
@@ -542,10 +543,12 @@ class TxHandlerSpec extends AlephiumFlowActorSpec {
     blockFlow.getMemPool(chainIndex).size is 0
 
     val status = blockFlow.getTxStatus(tx.id, chainIndex).rightValue.get
-    status.chainConfirmations is 1
-    status.fromGroupConfirmations is 1
-    status.toGroupConfirmations is 1
-    val blockHash = status.index.hash
+    status is a[BlockFlowState.Confirmed]
+    val confirmed = status.asInstanceOf[BlockFlowState.Confirmed]
+    confirmed.chainConfirmations is 1
+    confirmed.fromGroupConfirmations is 1
+    confirmed.toGroupConfirmations is 1
+    val blockHash = confirmed.index.hash
     blockFlow.getBestDeps(chainIndex.from).deps.contains(blockHash) is true
   }
 

--- a/io/src/main/scala/org/alephium/io/CachedKV.scala
+++ b/io/src/main/scala/org/alephium/io/CachedKV.scala
@@ -27,7 +27,7 @@ abstract class CachedKV[K, V, C >: Modified[V] <: Cache[V]] extends MutableKV[K,
 
   def get(key: K): IOResult[V] = {
     getOpt(key).flatMap {
-      case None        => Left(IOError.keyNotFound(key, "CachedTrie.get"))
+      case None        => Left(IOError.keyNotFound(key, "CachedKV.get"))
       case Some(value) => Right(value)
     }
   }

--- a/io/src/main/scala/org/alephium/io/MutableKV.scala
+++ b/io/src/main/scala/org/alephium/io/MutableKV.scala
@@ -21,3 +21,9 @@ trait MutableKV[K, V, T] extends ReadableKV[K, V] {
 
   def put(key: K, value: V): IOResult[T]
 }
+
+object MutableKV {
+  trait WithInitialValue[K, V, T] { Self: MutableKV[K, V, T] =>
+    def getInitialValue(key: K): IOResult[Option[V]]
+  }
+}

--- a/io/src/main/scala/org/alephium/io/RocksDBSource.scala
+++ b/io/src/main/scala/org/alephium/io/RocksDBSource.scala
@@ -35,14 +35,15 @@ object RocksDBSource {
 
   object ColumnFamily {
 
-    case object All       extends ColumnFamily("all")
-    case object Block     extends ColumnFamily("block")
-    case object Broker    extends ColumnFamily("broker")
-    case object Header    extends ColumnFamily("header")
-    case object PendingTx extends ColumnFamily("pendingtx")
-    case object ReadyTx   extends ColumnFamily("readytx")
-    case object Trie      extends ColumnFamily("trie")
-    case object Log       extends ColumnFamily("log")
+    case object All        extends ColumnFamily("all")
+    case object Block      extends ColumnFamily("block")
+    case object Broker     extends ColumnFamily("broker")
+    case object Header     extends ColumnFamily("header")
+    case object PendingTx  extends ColumnFamily("pendingtx")
+    case object ReadyTx    extends ColumnFamily("readytx")
+    case object Trie       extends ColumnFamily("trie")
+    case object Log        extends ColumnFamily("log")
+    case object LogCounter extends ColumnFamily("logcounter")
 
     val values: AVector[ColumnFamily] =
       AVector(All, Block, Broker, Header, Log, PendingTx, ReadyTx, Trie)

--- a/io/src/main/scala/org/alephium/io/RocksDBSource.scala
+++ b/io/src/main/scala/org/alephium/io/RocksDBSource.scala
@@ -46,7 +46,7 @@ object RocksDBSource {
     case object LogCounter extends ColumnFamily("logcounter")
 
     val values: AVector[ColumnFamily] =
-      AVector(All, Block, Broker, Header, Log, PendingTx, ReadyTx, Trie)
+      AVector(All, Block, Broker, Header, Log, LogCounter, PendingTx, ReadyTx, Trie)
   }
 
   final case class Compaction(

--- a/io/src/test/scala/org/alephium/io/StagingSMTSpec.scala
+++ b/io/src/test/scala/org/alephium/io/StagingSMTSpec.scala
@@ -28,7 +28,7 @@ class StagingSMTSpec extends AlephiumSpec {
     stagingCache.put(key0, value0)
     stagingCache.get(key0) isE value0
     stagingCache.underlying.get(key0).leftValue.getMessage is
-      IOError.keyNotFound(key0, "CachedTrie.get").getMessage
+      IOError.keyNotFound(key0, "CachedKV.get").getMessage
   }
 
   it should "commit changes in cache" in new Fixture {
@@ -41,8 +41,8 @@ class StagingSMTSpec extends AlephiumSpec {
     stagingCache.rollback()
     stagingCache.caches.isEmpty is true
     stagingCache.get(key0).leftValue.getMessage is
-      IOError.keyNotFound(key0, "CachedTrie.get").getMessage
+      IOError.keyNotFound(key0, "CachedKV.get").getMessage
     stagingCache.underlying.get(key0).leftValue.getMessage is
-      IOError.keyNotFound(key0, "CachedTrie.get").getMessage
+      IOError.keyNotFound(key0, "CachedKV.get").getMessage
   }
 }

--- a/protocol/src/main/scala/org/alephium/protocol/vm/CachedLogCounterState.scala
+++ b/protocol/src/main/scala/org/alephium/protocol/vm/CachedLogCounterState.scala
@@ -19,24 +19,25 @@ package org.alephium.protocol.vm
 import scala.collection.mutable
 
 import org.alephium.io._
+import org.alephium.protocol.Hash
 
-final class CachedLogStates(
-    val underlying: KeyValueStorage[LogStatesId, LogStates],
-    val caches: mutable.LinkedHashMap[LogStatesId, Cache[LogStates]]
-) extends CachedKV[LogStatesId, LogStates, Cache[LogStates]] {
-  protected def getOptFromUnderlying(key: LogStatesId): IOResult[Option[LogStates]] = {
+final class CachedLogCounterState(
+    val underlying: KeyValueStorage[Hash, Int],
+    val caches: mutable.Map[Hash, Cache[Int]]
+) extends CachedKV[Hash, Int, Cache[Int]] {
+  protected def getOptFromUnderlying(key: Hash): IOResult[Option[Int]] = {
     CachedKV.getOptFromUnderlying(underlying, caches, key)
   }
 
-  def persist(): IOResult[KeyValueStorage[LogStatesId, LogStates]] = {
+  def persist(): IOResult[KeyValueStorage[Hash, Int]] = {
     CachedKV.persist(underlying, caches)
   }
 
-  def staging(): StagingLogStates = new StagingLogStates(this, mutable.LinkedHashMap.empty)
+  def staging(): StagingLogCounterState = new StagingLogCounterState(this, mutable.Map.empty)
 }
 
-object CachedLogStates {
-  def from(storage: KeyValueStorage[LogStatesId, LogStates]): CachedLogStates = {
-    new CachedLogStates(storage, mutable.LinkedHashMap.empty)
+object CachedLogCounterState {
+  def from(storage: KeyValueStorage[Hash, Int]): CachedLogCounterState = {
+    new CachedLogCounterState(storage, mutable.Map.empty)
   }
 }

--- a/protocol/src/main/scala/org/alephium/protocol/vm/CachedLogCounterState.scala
+++ b/protocol/src/main/scala/org/alephium/protocol/vm/CachedLogCounterState.scala
@@ -33,13 +33,14 @@ final class CachedLogCounterState(
   }
 
   def persist(): IOResult[KeyValueStorage[Hash, Int]] = {
+    clearInitialValues()
     CachedKV.persist(underlying, caches)
   }
 
   def getInitialValue(key: Hash): IOResult[Option[Int]] = {
     (initialCounts.get(key): @unchecked) match {
       case None =>
-        super.getOpt(key).map { countOpt =>
+        getOpt(key).map { countOpt =>
           val count = countOpt.getOrElse(0)
           initialCounts.put(key, count)
           countOpt
@@ -49,7 +50,14 @@ final class CachedLogCounterState(
     }
   }
 
-  def staging(): StagingLogCounterState = new StagingLogCounterState(this, mutable.Map.empty)
+  def clearInitialValues(): Unit = {
+    initialCounts.clear()
+  }
+
+  def staging(): StagingLogCounterState = {
+    clearInitialValues()
+    new StagingLogCounterState(this, mutable.Map.empty)
+  }
 }
 
 object CachedLogCounterState {

--- a/protocol/src/main/scala/org/alephium/protocol/vm/LogStates.scala
+++ b/protocol/src/main/scala/org/alephium/protocol/vm/LogStates.scala
@@ -21,11 +21,11 @@ import org.alephium.protocol.vm.Val
 import org.alephium.serde.Serde
 import org.alephium.util.AVector
 
-final case class LogStatesId(blockHash: BlockHash, eventKey: Hash)
+final case class LogStatesId(eventKey: Hash, counter: Int)
 
 object LogStatesId {
   implicit val serde: Serde[LogStatesId] =
-    Serde.forProduct2(LogStatesId.apply, id => (id.blockHash, id.eventKey))
+    Serde.forProduct2(LogStatesId.apply, id => (id.eventKey, id.counter))
 }
 
 final case class LogState(

--- a/protocol/src/main/scala/org/alephium/protocol/vm/StagingLogCounterState.scala
+++ b/protocol/src/main/scala/org/alephium/protocol/vm/StagingLogCounterState.scala
@@ -36,4 +36,14 @@ final class StagingLogCounterState(
       }
     }
   }
+
+  override def rollback(): Unit = {
+    underlying.clearInitialValues()
+    super.rollback()
+  }
+
+  override def commit(): Unit = {
+    underlying.clearInitialValues()
+    super.commit()
+  }
 }

--- a/protocol/src/main/scala/org/alephium/protocol/vm/StagingLogCounterState.scala
+++ b/protocol/src/main/scala/org/alephium/protocol/vm/StagingLogCounterState.scala
@@ -19,24 +19,9 @@ package org.alephium.protocol.vm
 import scala.collection.mutable
 
 import org.alephium.io._
+import org.alephium.protocol.Hash
 
-final class CachedLogStates(
-    val underlying: KeyValueStorage[LogStatesId, LogStates],
-    val caches: mutable.LinkedHashMap[LogStatesId, Cache[LogStates]]
-) extends CachedKV[LogStatesId, LogStates, Cache[LogStates]] {
-  protected def getOptFromUnderlying(key: LogStatesId): IOResult[Option[LogStates]] = {
-    CachedKV.getOptFromUnderlying(underlying, caches, key)
-  }
-
-  def persist(): IOResult[KeyValueStorage[LogStatesId, LogStates]] = {
-    CachedKV.persist(underlying, caches)
-  }
-
-  def staging(): StagingLogStates = new StagingLogStates(this, mutable.LinkedHashMap.empty)
-}
-
-object CachedLogStates {
-  def from(storage: KeyValueStorage[LogStatesId, LogStates]): CachedLogStates = {
-    new CachedLogStates(storage, mutable.LinkedHashMap.empty)
-  }
-}
+final class StagingLogCounterState(
+    val underlying: CachedLogCounterState,
+    val caches: mutable.Map[Hash, Modified[Int]]
+) extends StagingKV[Hash, Int] {}

--- a/protocol/src/main/scala/org/alephium/protocol/vm/WorldState.scala
+++ b/protocol/src/main/scala/org/alephium/protocol/vm/WorldState.scala
@@ -446,7 +446,6 @@ object WorldState {
     ): IOResult[Unit] = {
       for {
         initialCount <- logCounterState.getInitialValue(eventKey).map(_.getOrElse(0))
-        currentCount <- logCounterState.getOpt(eventKey).map(_.getOrElse(0))
         id = LogStatesId(eventKey, initialCount)
         logStatesOpt <- logState.getOpt(id)
         _ <- logStatesOpt match {
@@ -455,7 +454,7 @@ object WorldState {
           case None =>
             logState.put(id, LogStates(blockHash, eventKey, AVector(state)))
         }
-        _ <- logCounterState.put(eventKey, currentCount + 1)
+        _ <- logCounterState.put(eventKey, initialCount + 1)
       } yield ()
     }
 

--- a/protocol/src/test/scala/org/alephium/protocol/vm/VMFactory.scala
+++ b/protocol/src/test/scala/org/alephium/protocol/vm/VMFactory.scala
@@ -21,9 +21,10 @@ import org.alephium.protocol.Hash
 
 trait VMFactory extends StorageFixture {
   lazy val cachedWorldState: WorldState.Cached = {
-    val storage = newDBStorage()
-    val trieDb  = newDB[Hash, SparseMerkleTrie.Node](storage, RocksDBSource.ColumnFamily.All)
-    val logDb   = newDB[LogStatesId, LogStates](storage, RocksDBSource.ColumnFamily.Log)
-    WorldState.emptyCached(trieDb, logDb)
+    val storage      = newDBStorage()
+    val trieDb       = newDB[Hash, SparseMerkleTrie.Node](storage, RocksDBSource.ColumnFamily.All)
+    val logDb        = newDB[LogStatesId, LogStates](storage, RocksDBSource.ColumnFamily.Log)
+    val logCounterDb = newDB[Hash, Int](storage, RocksDBSource.ColumnFamily.LogCounter)
+    WorldState.emptyCached(trieDb, logDb, logCounterDb)
   }
 }

--- a/protocol/src/test/scala/org/alephium/protocol/vm/WorldStateSpec.scala
+++ b/protocol/src/test/scala/org/alephium/protocol/vm/WorldStateSpec.scala
@@ -118,7 +118,8 @@ class WorldStateSpec extends AlephiumSpec with NoIndexModelGenerators with Stora
     test(
       WorldState.emptyCached(
         newDB(storage, RocksDBSource.ColumnFamily.All),
-        newDB(storage, RocksDBSource.ColumnFamily.Log)
+        newDB(storage, RocksDBSource.ColumnFamily.Log),
+        newDB(storage, RocksDBSource.ColumnFamily.LogCounter)
       )
     )
   }
@@ -128,7 +129,8 @@ class WorldStateSpec extends AlephiumSpec with NoIndexModelGenerators with Stora
     test(
       WorldState.emptyPersisted(
         newDB(storage, RocksDBSource.ColumnFamily.All),
-        newDB(storage, RocksDBSource.ColumnFamily.Log)
+        newDB(storage, RocksDBSource.ColumnFamily.Log),
+        newDB(storage, RocksDBSource.ColumnFamily.LogCounter)
       )
     )
   }
@@ -144,7 +146,8 @@ class WorldStateSpec extends AlephiumSpec with NoIndexModelGenerators with Stora
     val worldState = WorldState
       .emptyCached(
         newDB(storage, RocksDBSource.ColumnFamily.All),
-        newDB(storage, RocksDBSource.ColumnFamily.Log)
+        newDB(storage, RocksDBSource.ColumnFamily.Log),
+        newDB(storage, RocksDBSource.ColumnFamily.LogCounter)
       )
       .staging()
 
@@ -169,7 +172,8 @@ class WorldStateSpec extends AlephiumSpec with NoIndexModelGenerators with Stora
     val storage = newDBStorage()
     val worldState = WorldState.emptyCached(
       newDB(storage, RocksDBSource.ColumnFamily.All),
-      newDB(storage, RocksDBSource.ColumnFamily.Log)
+      newDB(storage, RocksDBSource.ColumnFamily.Log),
+      newDB(storage, RocksDBSource.ColumnFamily.LogCounter)
     )
     val staging = worldState.staging()
 


### PR DESCRIPTION
- Use `(eventKey, counter)` as key for log storage
- Change events API for `contract` and `txScript` to take counter instead

