### PR TITLE
Convert `EndpointSender` to a stoppable `Service`

### DIFF
--- a/app/src/main/scala/org/alephium/app/EndpointsLogic.scala
+++ b/app/src/main/scala/org/alephium/app/EndpointsLogic.scala
@@ -26,7 +26,6 @@ import akka.util.Timeout
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.exporter.common.TextFormat
 import sttp.model.{StatusCode, Uri}
-import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.tapir.server.ServerEndpoint
 
 import org.alephium.api.{ApiError, Endpoints, Try}
@@ -51,10 +50,11 @@ import org.alephium.serde._
 import org.alephium.util._
 
 // scalastyle:off method.length
-trait EndpointsLogic extends Endpoints with EndpointSender with SttpClientInterpreter {
+trait EndpointsLogic extends Endpoints {
   def node: Node
   def miner: ActorRefT[Miner.Command]
   def blocksExporter: BlocksExporter
+  def endpointSender: EndpointSender
 
   private lazy val blockFlow: BlockFlow                        = node.blockFlow
   private lazy val txHandler: ActorRefT[TxHandler.Command]     = node.allHandlers.txHandler
@@ -698,7 +698,7 @@ trait EndpointsLogic extends Endpoints with EndpointSender with SttpClientInterp
         uriFromGroup(groupIndex).flatMap {
           case Left(error) => Future.successful(Left(error))
           case Right(uri) =>
-            send(endpoint, params, uri)
+            endpointSender.send(endpoint, params, uri)
         }
     }
 

--- a/app/src/main/scala/org/alephium/app/RestServer.scala
+++ b/app/src/main/scala/org/alephium/app/RestServer.scala
@@ -24,14 +24,13 @@ import io.vertx.core.Vertx
 import io.vertx.core.http.{HttpMethod, HttpServer}
 import io.vertx.ext.web._
 import io.vertx.ext.web.handler.CorsHandler
-import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.tapir.server.vertx.VertxFutureServerInterpreter
 import sttp.tapir.server.vertx.VertxFutureServerInterpreter._
 
 import org.alephium.api.OpenAPIWriters.openApiJson
 import org.alephium.flow.client.Node
 import org.alephium.flow.mining.Miner
-import org.alephium.http.{ServerOptions, SwaggerVertx}
+import org.alephium.http.{EndpointSender, ServerOptions, SwaggerVertx}
 import org.alephium.protocol.config.BrokerConfig
 import org.alephium.util._
 import org.alephium.wallet.web.WalletServer
@@ -51,7 +50,6 @@ class RestServer(
     with Documentation
     with Service
     with VertxFutureServerInterpreter
-    with SttpClientInterpreter
     with StrictLogging {
 
   override val vertxFutureServerOptions = ServerOptions.serverOptions
@@ -59,6 +57,8 @@ class RestServer(
   val walletEndpoints                   = walletServer.map(_.walletEndpoints).getOrElse(List.empty)
 
   override val maybeApiKey = apiConfig.apiKey
+
+  val endpointSender: EndpointSender = new EndpointSender(maybeApiKey)
 
   private val swaggerUiRoute = new SwaggerVertx(openApiJson(openAPI, maybeApiKey.isEmpty)).route(_)
 
@@ -118,7 +118,7 @@ class RestServer(
   val routes: AVector[Router => Route] =
     walletServer.map(wallet => wallet.routes).getOrElse(AVector.empty) ++ blockFlowRoute
 
-  override def subServices: ArraySeq[Service] = ArraySeq(node)
+  override def subServices: ArraySeq[Service] = ArraySeq(node, endpointSender)
 
   private val vertx  = Vertx.vertx()
   private val router = Router.router(vertx)

--- a/http/src/main/scala/org/alephium/http/EndpointSender.scala
+++ b/http/src/main/scala/org/alephium/http/EndpointSender.scala
@@ -16,8 +16,10 @@
 
 package org.alephium.http
 
+import scala.collection.immutable.ArraySeq
 import scala.concurrent._
 
+import com.typesafe.scalalogging.StrictLogging
 import sttp.client3.Request
 import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
 import sttp.model.{StatusCode, Uri}
@@ -26,14 +28,26 @@ import sttp.tapir.client.sttp.SttpClientInterpreter
 
 import org.alephium.api.{ApiError, BaseEndpoint}
 import org.alephium.api.model.ApiKey
+import org.alephium.util.Service
 import org.alephium.util.Utils.getStackTrace
 
 // scalastyle:off method.length
-trait EndpointSender extends BaseEndpoint with SttpClientInterpreter {
+class EndpointSender(val maybeApiKey: Option[ApiKey])(implicit
+    val executionContext: ExecutionContext
+) extends BaseEndpoint
+    with SttpClientInterpreter
+    with Service
+    with StrictLogging {
 
   private val backend = AsyncHttpClientFutureBackend()
 
-  val maybeApiKey: Option[ApiKey]
+  protected def startSelfOnce(): Future[Unit] = Future.unit
+
+  protected def stopSelfOnce(): Future[Unit] = {
+    backend.close()
+  }
+
+  override def subServices: ArraySeq[Service] = ArraySeq.empty
 
   def createRequest[I, O](
       endpoint: BaseEndpoint[I, O],

--- a/wallet/src/main/scala/org/alephium/wallet/WalletApp.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/WalletApp.scala
@@ -28,6 +28,7 @@ import io.vertx.ext.web._
 import io.vertx.ext.web.handler.CorsHandler
 import sttp.tapir.server.vertx.VertxFutureServerInterpreter._
 
+import org.alephium.http.EndpointSender
 import org.alephium.protocol.config.GroupConfig
 import org.alephium.util.{AVector, Service}
 import org.alephium.wallet.config.WalletConfig
@@ -43,11 +44,16 @@ class WalletApp(config: WalletConfig)(implicit
     override def groups: Int = config.blockflow.groups
   }
 
+  private val endpointSender: EndpointSender = new EndpointSender(
+    config.blockflow.apiKey
+  )
+
   val blockFlowClient: BlockFlowClient =
     BlockFlowClient.apply(
       config.blockflow.uri,
       config.blockflow.blockflowFetchMaxAge,
-      config.blockflow.apiKey
+      config.blockflow.apiKey,
+      endpointSender
     )
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
@@ -66,7 +72,7 @@ class WalletApp(config: WalletConfig)(implicit
 
   private val bindingPromise: Promise[HttpServer] = Promise()
 
-  override val subServices: ArraySeq[Service] = ArraySeq(walletService)
+  override val subServices: ArraySeq[Service] = ArraySeq(walletService, endpointSender)
 
   protected def startSelfOnce(): Future[Unit] = {
     config.port match {

--- a/wallet/src/main/scala/org/alephium/wallet/web/BlockFlowClient.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/web/BlockFlowClient.scala
@@ -19,7 +19,6 @@ package org.alephium.wallet.web
 import scala.concurrent.{ExecutionContext, Future}
 
 import sttp.model.{StatusCode, Uri}
-import sttp.tapir.client.sttp._
 
 import org.alephium.api.{ApiError, Endpoints}
 import org.alephium.api.model._
@@ -60,24 +59,24 @@ object BlockFlowClient {
   def apply(
       defaultUri: Uri,
       blockflowFetchMaxAge: Duration,
-      maybeApiKey: Option[ApiKey]
+      maybeApiKey: Option[ApiKey],
+      endpointSender: EndpointSender
   )(implicit
       groupConfig: GroupConfig,
       executionContext: ExecutionContext
   ): BlockFlowClient =
-    new Impl(defaultUri, blockflowFetchMaxAge, maybeApiKey)
+    new Impl(defaultUri, blockflowFetchMaxAge, maybeApiKey, endpointSender)
 
   private class Impl(
       defaultUri: Uri,
       val blockflowFetchMaxAge: Duration,
-      val maybeApiKey: Option[ApiKey]
+      val maybeApiKey: Option[ApiKey],
+      endpointSender: EndpointSender
   )(implicit
       val groupConfig: GroupConfig,
       executionContext: ExecutionContext
   ) extends BlockFlowClient
-      with Endpoints
-      with EndpointSender
-      with SttpClientInterpreter {
+      with Endpoints {
 
     private def uriFromGroup(
         fromGroup: GroupIndex
@@ -100,7 +99,7 @@ object BlockFlowClient {
       uriFromGroup(fromGroup).flatMap {
         _.fold(
           e => Future.successful(Left(e)),
-          uri => send(endpoint, params, uri)
+          uri => endpointSender.send(endpoint, params, uri)
         )
       }
     }
@@ -169,7 +168,7 @@ object BlockFlowClient {
 
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     private def fetchSelfClique(): Future[Either[ApiError[_ <: StatusCode], SelfClique]] = {
-      send(getSelfClique, (), defaultUri)
+      endpointSender.send(getSelfClique, (), defaultUri)
     }
   }
 }

--- a/wallet/src/test/scala/org/alephium/wallet/service/WalletServiceSpec.scala
+++ b/wallet/src/test/scala/org/alephium/wallet/service/WalletServiceSpec.scala
@@ -25,6 +25,7 @@ import akka.actor.ActorSystem
 
 import org.alephium.api.model.{Amount, Destination}
 import org.alephium.crypto.wallet.Mnemonic
+import org.alephium.http.EndpointSender
 import org.alephium.protocol.{Generators, Hash, PrivateKey, PublicKey, SignatureSchema}
 import org.alephium.protocol.model.{Address, TxGenerators}
 import org.alephium.protocol.vm.LockupScript
@@ -282,11 +283,14 @@ class WalletServiceSpec extends AlephiumFutureSpec {
     implicit val system: ActorSystem =
       ActorSystem(s"wallet-service-spec-${Random.nextInt()}")
     implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+    lazy val endpointSender       = new EndpointSender(config.blockflow.apiKey)
+
     lazy val blockFlowClient =
       BlockFlowClient.apply(
         config.blockflow.uri,
         config.blockflow.blockflowFetchMaxAge,
-        config.blockflow.apiKey
+        config.blockflow.apiKey,
+        endpointSender
       )
 
     lazy val walletService: WalletService =


### PR DESCRIPTION
Resolves: #637

sttp backend needs to be closed to properly free up resources.