### PR TITLE
Fix swagger ui redirection

### DIFF
--- a/http/src/main/scala/org/alephium/http/SwaggerUI.scala
+++ b/http/src/main/scala/org/alephium/http/SwaggerUI.scala
@@ -58,7 +58,7 @@ object SwaggerUI {
     val swaggerInitializerJsWithExtended =
       s"""|window.onload = function() {
           |  window.ui = SwaggerUIBundle({
-          |    url: "/docs/openapi.json",
+          |    url: "/docs/$openapiFileName",
           |    tryItOutEnabled: true,
           |    dom_id: '#swagger-ui',
           |    deepLinking: true,


### PR DESCRIPTION
very small fix, but necessary so I can use `SwaggerUI` in `explorer-backend`. Without this it redirect to `/docs/openapi.json` while I have define another file name.