### PR TITLE
#668: Line number information in error messages

### DIFF
--- a/ralph/src/main/scala/org/alephium/ralph/CompilerError.scala
+++ b/ralph/src/main/scala/org/alephium/ralph/CompilerError.scala
@@ -1,0 +1,69 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.ralph
+
+import fastparse.P
+
+/** Typed compiler errors.
+  */
+sealed trait CompilerError {
+  def productPrefix: String
+
+  def message: String =
+    productPrefix
+}
+
+object CompilerError {
+
+  /** Creates a failed parser result.
+    *
+    * @param error
+    *   the parser error or error cause.
+    * @param index
+    *   location of where this error occurred. `0` being the first character.
+    * @param cut
+    *   if true, disables back-tracking.
+    * @param ctx
+    *   FastParser context.
+    * @return
+    *   A parser run.
+    */
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+  def apply(error: CompilerError, index: Int, cut: Boolean = true)(implicit
+      ctx: P[_]
+  ): P[Nothing] = {
+    // we can use ctx.freshFailure() here but it clears the stack when `verboseFailures = true`.
+    // Currently there is no obvious reason to clear this stack.
+    ctx.isSuccess = false
+    // `verboseFailures = false` is equivalent to cut in this case.
+    // Actual cut syntax `~/` that gets used by macros in parsers to generate relevant code which does not work here.
+    // Setting `ctx.verboseFailures = false` tells FastParse to stop collecting stack
+    // for previous successful parsers and that `verboseFailures` is valid only for this `CompilerError`.
+    // To enable collecting stack information set `cut = false`.
+    if (cut) ctx.verboseFailures = false
+    // set the error message
+    ctx.setMsg(index, () => error.message)
+    // prepend to existing stack so it shows this error as the latest error on the stack.
+    ctx.failureStack = (error.message, index) :: ctx.failureStack
+    // set the error index and return as failure.
+    ctx.augmentFailure(index = index)
+  }
+
+  case object `an I256 or U256 value` extends CompilerError
+  case object `an I256 value`         extends CompilerError
+
+}

--- a/ralph/src/main/scala/org/alephium/ralph/Lexer.scala
+++ b/ralph/src/main/scala/org/alephium/ralph/Lexer.scala
@@ -89,18 +89,21 @@ object Lexer {
       case ("-", i) => i.negate()
       case (_, i)   => i
     }
-  def typedNum[Unknown: P]: P[Val] =
-    P(num ~ ("i" | "u").?.!)
-      .map {
-        case (n, postfix) if Number.isNegative(n) || postfix == "i" =>
+  def typedNum[T](implicit ctx: P[T]): P[Val] =
+    P(Index ~ num ~ ("i" | "u").?.!)(
+      sourcecode.Name(CompilerError.`an I256 or U256 value`.message),
+      ctx
+    )
+      .flatMap {
+        case (index, n, postfix) if Number.isNegative(n) || postfix == "i" =>
           I256.from(n) match {
-            case Some(value) => Val.I256(value)
-            case None        => throw Compiler.Error(s"Invalid I256 value: $n")
+            case Some(value) => Pass(Val.I256(value))
+            case None        => CompilerError(CompilerError.`an I256 value`, index)
           }
-        case (n, _) =>
+        case (index, n, _) =>
           U256.from(n) match {
-            case Some(value) => Val.U256(value)
-            case None        => throw Compiler.Error(s"Invalid U256 value: $n")
+            case Some(value) => Pass(Val.U256(value))
+            case None        => CompilerError(CompilerError.`an I256 or U256 value`, index)
           }
       }
 


### PR DESCRIPTION
- Towards #668
- Added `CompilerError` for creating parser failures to replace throwing `Compiler.Error` exception.
- `CompilerError` are typed error messages instead of directly working with `String`. FastParse also uses `String` but these types might be needed when implementing [Task 3](#668).

## Test 1

Instead of displaying the function name `typedNum` in error, this displays a message. 

```scala
fastparse.parse("a", Lexer.typedNum(_))
// Existing error message using Exceptions
Expected typedNum:1:1 / num:1:1 / (hexNum | decNum):1:1, found "a"
// Updated error message within FastParse
Expected an I256 or U256 value:1:1 / num:1:1 / (hexNum | decNum):1:1, found "a"
```

## Test 2

```scala
fastparse.parse("123456789" * 10, Lexer.typedNum(_))
//Existing error message using Exceptions
Invalid U256 value: 123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789
//Updated error message within FastParse
Expected an I256 or U256 value:1:1, found "1234567891"
```

Note, the updated error message does not display the entire invalid input because of this [`index + 10`](https://github.com/com-lihaoyi/fastparse/blob/af4b47f25bdf7e85bf6196676db84805fb6e5358/fastparse/src/fastparse/Parsed.scala#L108). Do we want the entire invalid value displayed after `found`? Task 3 would kinda take care of this by pointing to where the error occurred.

## Test 3

```scala
fastparse.parse("-" + ("123456789" * 10), Lexer.typedNum(_))
//Existing error message using Exceptions
Invalid I256 value: -123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789
//Updated error message within FastParse
Expected an I256 value:1:1, found "-123456789"
```

## Test 4

```scala
fastparse.parse(("123456789" * 10) + "i", Lexer.typedNum(_))
//Existing error message using Exceptions
Invalid I256 value: 123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789
//Updated error message within FastParse
Expected an I256 value:1:1, found "1234567891"
```

## Test 5

```scala
val errorAssetScript: String =
  s"""
     |// comment
     |AssetScript Foo {
     |  pub fn bar(a: U256, b: U256) -> (U256) {
     |    let c = 123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789
     |    return (a + b + c)
     |  }
     |}
     |""".stripMargin

//Existing error message using Exceptions
Invalid U256 value: 123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789
//Updated error message within FastParse
Expected an I256 or U256 value:5:13, found "1234567891"
```
