### PR TITLE
Print Correct Error Message with Wrong Prefixed StdId

### DIFF
--- a/ralph/src/main/scala/org/alephium/ralph/Ast.scala
+++ b/ralph/src/main/scala/org/alephium/ralph/Ast.scala
@@ -1499,8 +1499,8 @@ object Ast {
             }
             if (!stdId.bytes.startsWith(parentStdId.bytes)) {
               throw Compiler.Error(
-                s"The std id of interface ${interface.ident.name} should starts with ${Hex
-                    .toHexString(parentStdId.bytes)}"
+                s"The std id of interface ${interface.ident.name} should start with ${Hex
+                    .toHexString(parentStdId.bytes.drop(Ast.StdInterfaceIdPrefix.length))}"
               )
             }
             Some(stdId)

--- a/ralph/src/test/scala/org/alephium/ralph/AstSpec.scala
+++ b/ralph/src/test/scala/org/alephium/ralph/AstSpec.scala
@@ -688,50 +688,54 @@ class AstSpec extends AlephiumSpec {
     val bar = foo.copy(ident = Ast.TypeId("Bar"))
     val baz = foo.copy(ident = Ast.TypeId("Baz"))
 
+    def stdId(raw: String) = {
+      Val.ByteVec(Ast.StdInterfaceIdPrefix ++ Hex.unsafe(raw))
+    }
+
     Ast.MultiContract.getStdId(Seq.empty) is None
     Ast.MultiContract.getStdId(Seq(foo)) is None
     Ast.MultiContract.getStdId(
-      Seq(foo.copy(stdId = Some(Val.ByteVec(Hex.unsafe("0001")))))
-    ) is Some(Val.ByteVec(Hex.unsafe("0001")))
+      Seq(foo.copy(stdId = Some(stdId("0001"))))
+    ) is Some(stdId("0001"))
     Ast.MultiContract.getStdId(Seq(foo, bar, baz)) is None
     Ast.MultiContract.getStdId(
-      Seq(foo.copy(stdId = Some(Val.ByteVec(Hex.unsafe("0001")))), bar, baz)
-    ) is Some(Val.ByteVec(Hex.unsafe("0001")))
+      Seq(foo.copy(stdId = Some(stdId("0001"))), bar, baz)
+    ) is Some(stdId("0001"))
     Ast.MultiContract.getStdId(
-      Seq(foo, bar.copy(stdId = Some(Val.ByteVec(Hex.unsafe("0001")))), baz)
-    ) is Some(Val.ByteVec(Hex.unsafe("0001")))
+      Seq(foo, bar.copy(stdId = Some(stdId("0001"))), baz)
+    ) is Some(stdId("0001"))
     Ast.MultiContract.getStdId(
       Seq(
-        foo.copy(stdId = Some(Val.ByteVec(Hex.unsafe("0001")))),
+        foo.copy(stdId = Some(stdId("0001"))),
         bar,
-        baz.copy(stdId = Some(Val.ByteVec(Hex.unsafe("000101"))))
+        baz.copy(stdId = Some(stdId("000101")))
       )
-    ) is Some(Val.ByteVec(Hex.unsafe("000101")))
+    ) is Some(stdId("000101"))
     Ast.MultiContract.getStdId(
       Seq(
-        foo.copy(stdId = Some(Val.ByteVec(Hex.unsafe("0001")))),
-        bar.copy(stdId = Some(Val.ByteVec(Hex.unsafe("000101")))),
-        baz.copy(stdId = Some(Val.ByteVec(Hex.unsafe("00010101"))))
+        foo.copy(stdId = Some(stdId("0001"))),
+        bar.copy(stdId = Some(stdId("000101"))),
+        baz.copy(stdId = Some(stdId("00010101")))
       )
-    ) is Some(Val.ByteVec(Hex.unsafe("00010101")))
+    ) is Some(stdId("00010101"))
     intercept[Compiler.Error](
       Ast.MultiContract.getStdId(
         Seq(
-          foo.copy(stdId = Some(Val.ByteVec(Hex.unsafe("0001")))),
+          foo.copy(stdId = Some(stdId("0001"))),
           bar,
-          baz.copy(stdId = Some(Val.ByteVec(Hex.unsafe("0001"))))
+          baz.copy(stdId = Some(stdId("0001")))
         )
       )
     ).message is "The std id of interface Baz is the same as parent interface"
     intercept[Compiler.Error](
       Ast.MultiContract.getStdId(
         Seq(
-          foo.copy(stdId = Some(Val.ByteVec(Hex.unsafe("0001")))),
+          foo.copy(stdId = Some(stdId("0001"))),
           bar,
-          baz.copy(stdId = Some(Val.ByteVec(Hex.unsafe("0002"))))
+          baz.copy(stdId = Some(stdId("0002")))
         )
       )
-    ).message is "The std id of interface Baz should starts with 0001"
+    ).message is "The std id of interface Baz should start with 0001"
   }
 
   it should "check if the contract std id enabled" in {

--- a/ralph/src/test/scala/org/alephium/ralph/CompilerSpec.scala
+++ b/ralph/src/test/scala/org/alephium/ralph/CompilerSpec.scala
@@ -4064,4 +4064,23 @@ class CompilerSpec extends AlephiumSpec with ContextGenerators {
     compile("Bar.bar()").leftValue.message is
       s"""Expected static function, got "Bar.bar""""
   }
+
+  it should "should print correct error message when std is not prefixed correctly" in {
+    val code = s"""
+                  |@std(id = #0005)
+                  |Interface Foo {
+                  |    pub fn foo() -> ()
+                  |}
+                  |
+                  |@std(id = #000401)
+                  |Interface Bar extends Foo {
+                  |    pub fn foo() -> ()
+                  |}
+                  |""".stripMargin
+
+    Compiler
+      .compileContractFull(code)
+      .leftValue
+      .message is "The std id of interface Bar should start with 0005"
+  }
 }


### PR DESCRIPTION
With the following code
```
 @std(id = #0005)
 Interface Foo {
    pub fn foo() -> ()                                                                                                                                                                                                                    
 }

 @std(id = #000401)
 Interface Bar extends Foo {
    pub fn bar() -> ()                                                                                                                                                                                                                    
 }
```
The compiler will print `The std id of interface Bar should starts with 414c50480005` instead of `The std id of interface Bar should starts with 0005`