### PR TITLE
Check if wallets secret dir exist before creating it

### DIFF
--- a/wallet/src/main/scala/org/alephium/wallet/service/WalletService.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/service/WalletService.scala
@@ -248,7 +248,11 @@ object WalletService {
     private val path: AVector[Int] = Constants.path
 
     protected def startSelfOnce(): Future[Unit] = {
-      Future.fromTry(Try(discard(Files.createDirectories(secretDir))))
+      if (Files.exists(secretDir)) {
+        Future.unit
+      } else {
+        Future.fromTry(Try(discard(Files.createDirectories(secretDir))))
+      }
     }
 
     protected def stopSelfOnce(): Future[Unit] = {


### PR DESCRIPTION
Resolves: #959

From the java doc we can read:

```
Unlike the createDirectory method, an exception is not thrown if the directory 
could not be created because it already exists.
```

So it was fine to call the function on every start, but as mentioned in issue #959, it doesn't work with symbolic link because the function throws:

```
FileAlreadyExistsException - if dir exists but is not a directory (optional specific exception)
```

As here it's a link and not a directory, the error raised.

To fix this we can simply first check if the directory/link exists.