### PR TITLE
Restrict sign endpoint to 32 bytes hash only

### DIFF
--- a/api/src/main/resources/openapi.json
+++ b/api/src/main/resources/openapi.json
@@ -11899,7 +11899,8 @@
         "type": "object",
         "properties": {
           "data": {
-            "type": "string"
+            "type": "string",
+            "format": "32-byte-hash"
           }
         }
       },

--- a/api/src/main/scala/org/alephium/api/ApiModel.scala
+++ b/api/src/main/scala/org/alephium/api/ApiModel.scala
@@ -118,7 +118,7 @@ trait ApiModelCodec {
     _.toHexString
   )
   implicit val hashReader: Reader[Hash] =
-    byteStringReader.map(Hash.from(_).getOrElse(throw new Abort("cannot decode hash")))
+    byteStringReader.map(Hash.from(_).getOrElse(throw new Abort("cannot decode 32 bytes hash")))
 
   implicit val blockHashWriter: Writer[BlockHash] = StringWriter.comap[BlockHash](
     _.toHexString

--- a/wallet/src/main/scala/org/alephium/wallet/api/WalletExamples.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/api/WalletExamples.scala
@@ -154,7 +154,7 @@ trait WalletExamples extends EndpointsExamples {
   )
 
   implicit val signTransactionExamples: List[Example[Sign]] =
-    simpleExample(Sign(hash.toHexString))
+    simpleExample(Sign(hash))
 
   implicit val signTransactionResultExamples: List[Example[SignResult]] =
     simpleExample(SignResult(signature))

--- a/wallet/src/main/scala/org/alephium/wallet/api/model/Sign.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/api/model/Sign.scala
@@ -16,8 +16,8 @@
 
 package org.alephium.wallet.api.model
 
-import org.alephium.protocol.Signature
+import org.alephium.protocol.{Hash, Signature}
 
-final case class Sign(data: String)
+final case class Sign(data: Hash)
 
 final case class SignResult(signature: Signature)

--- a/wallet/src/main/scala/org/alephium/wallet/service/WalletService.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/service/WalletService.scala
@@ -33,11 +33,11 @@ import org.alephium.api.ApiError
 import org.alephium.api.model.{Amount, Destination, SweepAddressTransaction}
 import org.alephium.crypto.wallet.BIP32.ExtendedPrivateKey
 import org.alephium.crypto.wallet.Mnemonic
-import org.alephium.protocol.{Signature, SignatureSchema}
+import org.alephium.protocol.{Hash, Signature, SignatureSchema}
 import org.alephium.protocol.config.GroupConfig
 import org.alephium.protocol.model.{Address, GroupIndex, TransactionId}
 import org.alephium.protocol.vm.{GasBox, GasPrice}
-import org.alephium.util.{discard, AVector, Duration, FutureCollection, Hex, Service, TimeStamp}
+import org.alephium.util.{discard, AVector, Duration, FutureCollection, Service, TimeStamp}
 import org.alephium.wallet.Constants
 import org.alephium.wallet.api.model.{Addresses, AddressInfo}
 import org.alephium.wallet.storage.SecretStorage
@@ -103,7 +103,7 @@ trait WalletService extends Service {
   ): Future[Either[WalletError, AVector[(TransactionId, GroupIndex, GroupIndex)]]]
   def sign(
       wallet: String,
-      data: String
+      data: Hash
   ): Either[WalletError, Signature]
   def deriveNextAddress(
       wallet: String,
@@ -478,14 +478,10 @@ object WalletService {
 
     def sign(
         wallet: String,
-        data: String
+        data: Hash
     ): Either[WalletError, Signature] = {
       withPrivateKey(wallet) { privateKey =>
-        for {
-          bytes <- Hex.from(data).toRight(OtherError(s"Invalid hex string"))
-        } yield {
-          SignatureSchema.sign(bytes, privateKey.privateKey)
-        }
+        Right(SignatureSchema.sign(data.bytes, privateKey.privateKey))
       }
     }
 

--- a/wallet/src/test/scala/org/alephium/wallet/WalletAppSpec.scala
+++ b/wallet/src/test/scala/org/alephium/wallet/WalletAppSpec.scala
@@ -369,7 +369,13 @@ class WalletAppSpec
 
     sign("non-hex-data") check { response =>
       val error = response.as[ApiError.BadRequest]
-      error.detail is "Invalid hex string"
+      error.detail is "Invalid value for: body (Invalid hex string: non-hex-data at index 8: decoding failure)"
+      response.code is StatusCode.BadRequest
+    }
+
+    sign(Hex.toHexString(serialize(unsignedTx))) check { response =>
+      val error = response.as[ApiError.BadRequest]
+      error.detail is "Invalid value for: body (cannot decode 32 bytes hash at index 8: decoding failure)"
       response.code is StatusCode.BadRequest
     }
 

--- a/wallet/src/test/scala/org/alephium/wallet/service/WalletServiceSpec.scala
+++ b/wallet/src/test/scala/org/alephium/wallet/service/WalletServiceSpec.scala
@@ -217,7 +217,7 @@ class WalletServiceSpec extends AlephiumFutureSpec {
     val expected = SignatureSchema.sign(unsignedTx.id, privateKey)
 
     walletService
-      .sign(walletName, unsignedTx.id.toHexString)
+      .sign(walletName, unsignedTx.id.value)
       .rightValue is expected
   }
 
@@ -226,7 +226,7 @@ class WalletServiceSpec extends AlephiumFutureSpec {
     val expected = SignatureSchema.sign(data.bytes, privateKey)
 
     walletService
-      .sign(walletName, data.toHexString)
+      .sign(walletName, data)
       .rightValue is expected
   }
 
@@ -235,7 +235,7 @@ class WalletServiceSpec extends AlephiumFutureSpec {
     val expected = SignatureSchema.sign(data.bytes, privateKey)
 
     walletService
-      .sign(walletName, data.toHexString)
+      .sign(walletName, data)
       .rightValue is expected
   }
 


### PR DESCRIPTION
Many people are signing the `unsignedTx` and it's very confusing.

Resolves: #963