### PR TITLE
Add `Schema` to `Codec`

### DIFF
--- a/api/src/main/resources/openapi.json
+++ b/api/src/main/resources/openapi.json
@@ -1660,7 +1660,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "address"
             }
           }
         ],
@@ -3948,7 +3949,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "block-hash"
             }
           }
         ],
@@ -4151,7 +4153,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "block-hash"
             }
           }
         ],
@@ -4373,7 +4376,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "block-hash"
             }
           }
         ],
@@ -4470,7 +4474,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "address"
             }
           },
           {
@@ -4630,7 +4635,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "address"
             }
           }
         ],
@@ -4781,7 +4787,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "address"
             }
           }
         ],
@@ -5111,7 +5118,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "block-hash"
             }
           }
         ],
@@ -5741,7 +5749,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "32-byte-hash"
             }
           },
           {
@@ -5949,7 +5958,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "32-byte-hash"
             }
           },
           {
@@ -6306,7 +6316,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "32-byte-hash"
             }
           }
         ],
@@ -7426,7 +7437,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "address"
             }
           },
           {
@@ -9308,7 +9320,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "address"
             }
           },
           {
@@ -9451,7 +9464,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "address"
             }
           }
         ],
@@ -9549,7 +9563,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "32-byte-hash"
             }
           },
           {
@@ -9673,7 +9688,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "block-hash"
             }
           },
           {

--- a/api/src/main/scala/org/alephium/api/TapirSchemas.scala
+++ b/api/src/main/scala/org/alephium/api/TapirSchemas.scala
@@ -20,13 +20,13 @@ import java.math.BigInteger
 import java.net.{InetAddress, InetSocketAddress}
 
 import akka.util.ByteString
-import sttp.tapir.{FieldName, Schema}
+import sttp.tapir.{FieldName, Schema, Validator}
 import sttp.tapir.SchemaType.{SArray, SInteger, SProduct, SProductField, SString}
 
-import org.alephium.api.model.{Amount, BuildTxCommon, Script}
+import org.alephium.api.model.{Amount, ApiKey, BuildTxCommon, MinerAction, Script}
 import org.alephium.crypto.wallet.Mnemonic
 import org.alephium.protocol.{Hash, PublicKey, Signature}
-import org.alephium.protocol.model.{Address, BlockHash, CliqueId, GroupIndex, ReleaseVersion}
+import org.alephium.protocol.model._
 import org.alephium.protocol.vm.{GasBox, GasPrice, LockupScript, StatefulContract}
 import org.alephium.util.{AVector, TimeStamp, U256}
 
@@ -83,6 +83,12 @@ trait TapirSchemasLike {
 
   implicit val publicKeyTypeSchema: Schema[BuildTxCommon.PublicKeyType] =
     Schema(SString()).format("hex-string")
+
+  implicit val apiKeySchema: Schema[ApiKey] =
+    Schema(SString()).validate(Validator.minLength(32)).as[ApiKey]
+
+  implicit val transactionIdSchema: Schema[TransactionId] = Schema(SString()).format("32-byte-hash")
+  implicit val minerActionSchema: Schema[MinerAction]     = Schema(SString())
 }
 
 object TapirSchemas extends TapirSchemasLike


### PR DESCRIPTION
While tackling https://github.com/alephium/explorer-backend/issues/484

I realize we can improve our `Codec` to have the format added to our types when they are used in path query.
