### PR TITLE
Add `wallet.enabled` config

### DIFF
--- a/app/src/main/scala/org/alephium/app/Server.scala
+++ b/app/src/main/scala/org/alephium/app/Server.scala
@@ -42,23 +42,24 @@ trait Server extends Service {
   def storages: Storages
 
   lazy val node: Node = Node.build(storages, flowSystem)
-  lazy val walletApp: Option[WalletApp] = Option.when(config.network.isCoordinator) {
-    val walletConfig: WalletConfig = WalletConfig(
-      port = None,
-      config.wallet.secretDir,
-      config.wallet.lockingTimeout,
-      apiConfig.apiKey,
-      WalletConfig.BlockFlow(
-        apiConfig.networkInterface.getHostAddress,
-        config.network.restPort,
-        config.broker.groups,
-        apiConfig.blockflowFetchMaxAge,
-        apiConfig.apiKey
+  lazy val walletApp: Option[WalletApp] =
+    Option.when(config.wallet.enabled && config.network.isCoordinator) {
+      val walletConfig: WalletConfig = WalletConfig(
+        port = None,
+        config.wallet.secretDir,
+        config.wallet.lockingTimeout,
+        apiConfig.apiKey,
+        WalletConfig.BlockFlow(
+          apiConfig.networkInterface.getHostAddress,
+          config.network.restPort,
+          config.broker.groups,
+          apiConfig.blockflowFetchMaxAge,
+          apiConfig.apiKey
+        )
       )
-    )
 
-    new WalletApp(walletConfig)(executionContext)
-  }
+      new WalletApp(walletConfig)(executionContext)
+    }
 
   def blocksExporter: BlocksExporter
 

--- a/flow/src/main/resources/system_it.conf.tmpl
+++ b/flow/src/main/resources/system_it.conf.tmpl
@@ -89,6 +89,7 @@ alephium {
   }
 
   wallet {
+    enabled = true
     secret-dir = ""
     locking-timeout = 10 minutes
   }

--- a/flow/src/main/resources/system_prod.conf.tmpl
+++ b/flow/src/main/resources/system_prod.conf.tmpl
@@ -105,6 +105,8 @@ alephium {
   }
 
   wallet {
+    enabled = true
+    enabled = ${?ALEPHIUM_WALLET_ENABLE}
     home-dir = ${user.home}
     home-dir = ${?ALEPHIUM_WALLET_HOME}
 

--- a/flow/src/main/resources/system_test.conf.tmpl
+++ b/flow/src/main/resources/system_test.conf.tmpl
@@ -91,6 +91,7 @@ alephium {
   }
 
   wallet {
+    enabled = true
     secret-dir = ""
     locking-timeout = 10 minutes
   }

--- a/flow/src/main/scala/org/alephium/flow/setting/AlephiumConfig.scala
+++ b/flow/src/main/scala/org/alephium/flow/setting/AlephiumConfig.scala
@@ -174,7 +174,7 @@ final case class MemPoolSetting(
     autoMineForDev: Boolean // for dev only
 )
 
-final case class WalletSetting(secretDir: Path, lockingTimeout: Duration)
+final case class WalletSetting(enabled: Boolean, secretDir: Path, lockingTimeout: Duration)
 
 object WalletSetting {
   final case class BlockFlow(host: String, port: Int, groups: Int)


### PR DESCRIPTION
It doesn't make sense to have the wallet running on our public nodes, anyway the endpoints are not exposes, but still visible to the api doc.

When `enabled = false`, wallet isn't launched and thus endpoints are not there

![image](https://github.com/alephium/alephium/assets/2979182/474537ad-b684-477c-a1a7-4183269ee31d)
