### PR TITLE
Add `Ast.Positioned` to `Type`

### DIFF
--- a/ralph/src/main/scala/org/alephium/ralph/Type.scala
+++ b/ralph/src/main/scala/org/alephium/ralph/Type.scala
@@ -19,7 +19,7 @@ package org.alephium.ralph
 import org.alephium.protocol.vm.Val
 import org.alephium.util.AVector
 
-sealed trait Type {
+sealed trait Type extends Ast.Positioned {
   def toVal: Val.Type
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))


### PR DESCRIPTION
Currently it only make sense to add a source index to:
 - `NamedType`
 - `FixedSizeArray` 
 
Other `Type` aren't constructed at parsing or are case object and having the `var sourceIndex` don't make sense on them.