### PR TITLE
Fix flaky tests

### DIFF
--- a/flow/src/test/scala/org/alephium/flow/core/BlockFlowGroupViewSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/core/BlockFlowGroupViewSpec.scala
@@ -28,13 +28,14 @@ import org.alephium.util.{AlephiumSpec, AVector, TimeStamp}
 class BlockFlowGroupViewSpec extends AlephiumSpec {
   it should "fetch preOutputs" in new FlowFixture {
     val blockFlow1 = isolatedBlockFlow()
-    val block0     = transfer(blockFlow1, ChainIndex.unsafe(0, 1))
+    val now        = TimeStamp.now()
+    val block0     = transfer(blockFlow1, ChainIndex.unsafe(0, 1), now)
     addAndCheck(blockFlow1, block0)
-    val block1 = transfer(blockFlow1, ChainIndex.unsafe(0, 2))
+    val block1 = transfer(blockFlow1, ChainIndex.unsafe(0, 2), now.plusMillisUnsafe(1))
     addAndCheck(blockFlow1, block1)
-    val block2 = transfer(blockFlow1, ChainIndex.unsafe(0, 1))
+    val block2 = transfer(blockFlow1, ChainIndex.unsafe(0, 1), now.plusMillisUnsafe(2))
     addAndCheck(blockFlow1, block2)
-    val block3 = transfer(blockFlow1, ChainIndex.unsafe(0, 0))
+    val block3 = transfer(blockFlow1, ChainIndex.unsafe(0, 0), now.plusMillisUnsafe(3))
     addAndCheck(blockFlow1, block3)
 
     addAndCheck(blockFlow, block0)
@@ -51,7 +52,6 @@ class BlockFlowGroupViewSpec extends AlephiumSpec {
       block0.nonCoinbase.head.unsigned.fixedOutputs.tail
     groupView1.getRelevantUtxos(lockupScript, Int.MaxValue).rightValue.map(_.output) is
       block0.nonCoinbase.head.unsigned.fixedOutputs.tail
-    val now = TimeStamp.now()
     grandPool.add(block1.chainIndex, tx1, now)
     mempool.contains(tx1) is true
 

--- a/flow/src/test/scala/org/alephium/flow/core/BlockFlowSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/core/BlockFlowSpec.scala
@@ -975,10 +975,16 @@ class BlockFlowSpec extends AlephiumSpec {
   it should "support sequential transactions" in new FlowFixture with Generators {
     override val configValues = Map(("alephium.broker.broker-num", 1))
 
+    var now = TimeStamp.now()
+    def nextBlockTs: TimeStamp = {
+      now = now.plusMillisUnsafe(1)
+      now
+    }
+
     forAll(groupIndexGen, groupIndexGen, groupIndexGen) { case (fromGroup, toGroup0, toGroup1) =>
-      val block0 = transfer(blockFlow, ChainIndex(fromGroup, toGroup0))
+      val block0 = transfer(blockFlow, ChainIndex(fromGroup, toGroup0), nextBlockTs)
       addAndCheck(blockFlow, block0)
-      val block1 = transfer(blockFlow, ChainIndex(fromGroup, toGroup1))
+      val block1 = transfer(blockFlow, ChainIndex(fromGroup, toGroup1), nextBlockTs)
       addAndCheck(blockFlow, block1)
     }
   }


### PR DESCRIPTION
`BlockFlowGroupViewSpec` sometimes fails in Windows because we sort blocks by timestamp when updating the state: https://github.com/alephium/alephium/blob/56dc17a40bf1f0944d027f529c716fbe137f1d3d/flow/src/main/scala/org/alephium/flow/core/BlockFlowState.scala#L406