### PR TITLE
Narrower return type for multi-contract parser

### DIFF
--- a/ralph/src/main/scala/org/alephium/ralph/Ast.scala
+++ b/ralph/src/main/scala/org/alephium/ralph/Ast.scala
@@ -902,7 +902,8 @@ object Ast {
   }
 
   sealed trait GlobalDefinition extends UniqueDef
-  final case class Struct(id: TypeId, fields: Seq[StructField]) extends GlobalDefinition {
+  sealed trait MultiContractDef extends GlobalDefinition
+  final case class Struct(id: TypeId, fields: Seq[StructField]) extends MultiContractDef {
     lazy val tpe: Type.Struct = Type.Struct(id)
 
     def name: String = id.name
@@ -1574,7 +1575,7 @@ object Ast {
   final case class ConstantVarDef[Ctx <: StatelessContext](
       ident: Ident,
       expr: Expr[Ctx]
-  ) extends GlobalDefinition
+  ) extends MultiContractDef
       with ConstantDefinition {
     def name: String = ident.name
   }
@@ -1585,7 +1586,7 @@ object Ast {
     def name: String = ident.name
   }
   final case class EnumDef[Ctx <: StatelessContext](id: TypeId, fields: Seq[EnumField[Ctx]])
-      extends GlobalDefinition {
+      extends MultiContractDef {
     def name: String = id.name
   }
   object EnumDef {
@@ -2174,7 +2175,7 @@ object Ast {
     }
   }
 
-  sealed trait ContractWithState extends ContractT[StatefulContext] {
+  sealed trait ContractWithState extends ContractT[StatefulContext] with MultiContractDef {
     def inheritances: Seq[Inheritance]
 
     def templateVars: Seq[Argument]

--- a/ralph/src/main/scala/org/alephium/ralph/Parser.scala
+++ b/ralph/src/main/scala/org/alephium/ralph/Parser.scala
@@ -1226,7 +1226,7 @@ class StatefulParser(val fileURI: Option[java.net.URI]) extends Parser[StatefulC
     }
   def interface[Unknown: P]: P[Ast.ContractInterface] = P(Start ~ rawInterface ~ End)
 
-  private def globalDefinition[Unknown: P]: P[Ast.GlobalDefinition] = P(
+  def globalDefinition[Unknown: P]: P[Ast.MultiContractDef] = P(
     rawTxScript | rawContract | rawInterface | rawStruct | constantVarDef | rawEnumDef
   )
 


### PR DESCRIPTION
Although the `globalDefinition` parser does not parse `AssetScript`, its return type still includes it. To avoid managing `Ast.AssetScript`, `ralph-lsp` had to use `Either[Ast.ContractWithState, Ast.Struct]`. But, with the new changes in version `3.4.0`, using a narrower type makes things much easier.

If there is a need to keep the return type of `Ast.GlobalDefinition` unchanged, please let me know, this is not a required change, it's just for ease of use.

Needed for https://github.com/alephium/ralph-lsp/pull/251.