### PR TITLE
Truncate addresses in openapi on mainnet only

### DIFF
--- a/api/src/main/scala/org/alephium/api/OpenApiWriters.scala
+++ b/api/src/main/scala/org/alephium/api/OpenApiWriters.scala
@@ -25,28 +25,38 @@ import sttp.apispec.openapi._
 import upickle.core.LinkedHashMap
 
 import org.alephium.json.Json._
+import org.alephium.protocol.model.NetworkId
 
 object OpenAPIWriters extends EndpointsExamples {
 
-  def openApiJson(openAPI: OpenAPI, dropAuth: Boolean): String = {
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+  def openApiJson(
+      openAPI: OpenAPI,
+      dropAuth: Boolean,
+      networkId: NetworkId = NetworkId.AlephiumMainNet
+  ): String = {
     val newOpenAPI = if (dropAuth) {
       dropSecurityFields(openAPI)
     } else {
       openAPI
     }
-    cleanOpenAPIResult(
+    val openApiJson =
       write(
         dropNullValues(writeJs(newOpenAPI)),
         indent = 2
       )
-    )
+    if (networkId == NetworkId.AlephiumMainNet) {
+      truncateAddresses(openApiJson)
+    } else {
+      openApiJson
+    }
   }
 
-  private def cleanOpenAPIResult(openAPI: String): String = {
+  private def truncateAddresses(openAPI: String): String = {
     openAPI.replaceAll(address.toBase58, address.toBase58.dropRight(2))
   }
 
-  def dropSecurityFields(openAPI: OpenAPI): OpenAPI = {
+  private def dropSecurityFields(openAPI: OpenAPI): OpenAPI = {
     val components: Option[Components] =
       openAPI.components.map(_.copy(securitySchemes = ListMap.empty))
     val paths: Paths = openAPI.paths.copy(pathItems = openAPI.paths.pathItems.map {

--- a/api/src/main/scala/org/alephium/api/OpenApiWriters.scala
+++ b/api/src/main/scala/org/alephium/api/OpenApiWriters.scala
@@ -32,7 +32,7 @@ object OpenAPIWriters extends EndpointsExamples {
   def openApiJson(
       openAPI: OpenAPI,
       dropAuth: Boolean,
-      truncateAddresses: Boolean // users could accidentally spend their own tokens
+      truncateAddresses: Boolean // users could accidentally spend their mainnet tokens
   ): String = {
     val newOpenAPI = if (dropAuth) {
       dropSecurityFields(openAPI)

--- a/api/src/main/scala/org/alephium/api/OpenApiWriters.scala
+++ b/api/src/main/scala/org/alephium/api/OpenApiWriters.scala
@@ -25,7 +25,6 @@ import sttp.apispec.openapi._
 import upickle.core.LinkedHashMap
 
 import org.alephium.json.Json._
-import org.alephium.protocol.model.NetworkId
 
 object OpenAPIWriters extends EndpointsExamples {
 
@@ -33,7 +32,7 @@ object OpenAPIWriters extends EndpointsExamples {
   def openApiJson(
       openAPI: OpenAPI,
       dropAuth: Boolean,
-      networkId: NetworkId = NetworkId.AlephiumMainNet
+      truncateAddresses: Boolean // users could accidentally spend their own tokens
   ): String = {
     val newOpenAPI = if (dropAuth) {
       dropSecurityFields(openAPI)
@@ -45,14 +44,14 @@ object OpenAPIWriters extends EndpointsExamples {
         dropNullValues(writeJs(newOpenAPI)),
         indent = 2
       )
-    if (networkId == NetworkId.AlephiumMainNet) {
-      truncateAddresses(openApiJson)
+    if (truncateAddresses) {
+      truncateAddressesFromOpenApi(openApiJson)
     } else {
       openApiJson
     }
   }
 
-  private def truncateAddresses(openAPI: String): String = {
+  private def truncateAddressesFromOpenApi(openAPI: String): String = {
     openAPI.replaceAll(address.toBase58, address.toBase58.dropRight(2))
   }
 

--- a/app/src/main/scala/org/alephium/app/RestServer.scala
+++ b/app/src/main/scala/org/alephium/app/RestServer.scala
@@ -32,6 +32,7 @@ import org.alephium.flow.client.Node
 import org.alephium.flow.mining.Miner
 import org.alephium.http.{EndpointSender, ServerOptions, SwaggerUI}
 import org.alephium.protocol.config.BrokerConfig
+import org.alephium.protocol.model.NetworkId
 import org.alephium.util._
 import org.alephium.wallet.web.WalletServer
 
@@ -60,8 +61,9 @@ class RestServer(
 
   val endpointSender: EndpointSender = new EndpointSender(maybeApiKey)
 
+  private val truncateAddresses = node.config.network.networkId == NetworkId.AlephiumMainNet
   private val swaggerUiRoute = SwaggerUI(
-    openApiJson(openAPI, maybeApiKey.isEmpty, node.config.network.networkId)
+    openApiJson(openAPI, maybeApiKey.isEmpty, truncateAddresses)
   ).map(route(_))
 
   private val blockFlowRoute: AVector[Router => Route] =

--- a/app/src/main/scala/org/alephium/app/RestServer.scala
+++ b/app/src/main/scala/org/alephium/app/RestServer.scala
@@ -60,7 +60,9 @@ class RestServer(
 
   val endpointSender: EndpointSender = new EndpointSender(maybeApiKey)
 
-  private val swaggerUiRoute = SwaggerUI(openApiJson(openAPI, maybeApiKey.isEmpty)).map(route(_))
+  private val swaggerUiRoute = SwaggerUI(
+    openApiJson(openAPI, maybeApiKey.isEmpty, node.config.network.networkId)
+  ).map(route(_))
 
   private val blockFlowRoute: AVector[Router => Route] =
     AVector(

--- a/app/src/test/scala/org/alephium/app/RestServerSpec.scala
+++ b/app/src/test/scala/org/alephium/app/RestServerSpec.scala
@@ -30,7 +30,7 @@ import org.scalatest.compatible.Assertion
 import sttp.client3.Response
 import sttp.model.StatusCode
 
-import org.alephium.api.{ApiError, ApiModel}
+import org.alephium.api.{ApiError, ApiModel, OpenAPIWriters}
 import org.alephium.api.UtilJson.avectorReadWriter
 import org.alephium.api.model._
 import org.alephium.app.ServerFixture.NodeDummy
@@ -978,7 +978,14 @@ abstract class RestServerSpec(
       val expectedOpenapi =
         read[ujson.Value](
           Using(Source.fromFile(openapiPath.getPath, "UTF-8")) { source =>
-            source.getLines().mkString("\n").replaceFirst("12973", s"$port")
+            source
+              .getLines()
+              .mkString("\n")
+              .replaceFirst("12973", s"$port")
+              .replaceAll(
+                OpenAPIWriters.address.toBase58.dropRight(2),
+                OpenAPIWriters.address.toBase58
+              )
           }.get
         )
 

--- a/app/src/test/scala/org/alephium/app/RestServerSpec.scala
+++ b/app/src/test/scala/org/alephium/app/RestServerSpec.scala
@@ -978,14 +978,8 @@ abstract class RestServerSpec(
       val expectedOpenapi =
         read[ujson.Value](
           Using(Source.fromFile(openapiPath.getPath, "UTF-8")) { source =>
-            source
-              .getLines()
-              .mkString("\n")
-              .replaceFirst("12973", s"$port")
-              .replaceAll(
-                OpenAPIWriters.address.toBase58.dropRight(2),
-                OpenAPIWriters.address.toBase58
-              )
+            val openApiJson = source.getLines().mkString("\n")
+            reverseAddressTruncation(openApiJson).replaceFirst("12973", s"$port")
           }.get
         )
 
@@ -1632,6 +1626,13 @@ trait RestServerFixture
 
   def getPort(group: GroupIndex): Int =
     servers.find(_.node.config.broker.contains(group)).get.port
+
+  def reverseAddressTruncation(openApiJson: String): String = {
+    openApiJson.replaceAll(
+      OpenAPIWriters.address.toBase58.dropRight(2),
+      OpenAPIWriters.address.toBase58
+    )
+  }
 
   // scalastyle:off no.equal
   def removeField(name: String, json: ujson.Value): ujson.Value = {

--- a/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
+++ b/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
@@ -43,8 +43,7 @@ object OpenApiUpdate extends App {
         override def groups: Int = 4
       }
 
-    private val json =
-      openApiJson(openAPI, dropAuth = maybeApiKey.isEmpty)
+    private val json = openApiJson(openAPI, dropAuth = maybeApiKey.isEmpty)
 
     import java.io.PrintWriter
     new PrintWriter("../api/src/main/resources/openapi.json") { write(json); close() }

--- a/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
+++ b/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
@@ -43,7 +43,8 @@ object OpenApiUpdate extends App {
         override def groups: Int = 4
       }
 
-    private val json = openApiJson(openAPI, dropAuth = maybeApiKey.isEmpty)
+    private val json =
+      openApiJson(openAPI, dropAuth = maybeApiKey.isEmpty)
 
     import java.io.PrintWriter
     new PrintWriter("../api/src/main/resources/openapi.json") { write(json); close() }

--- a/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
+++ b/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
@@ -43,7 +43,8 @@ object OpenApiUpdate extends App {
         override def groups: Int = 4
       }
 
-    private val json = openApiJson(openAPI, dropAuth = maybeApiKey.isEmpty)
+    private val json =
+      openApiJson(openAPI, dropAuth = maybeApiKey.isEmpty, truncateAddresses = true)
 
     import java.io.PrintWriter
     new PrintWriter("../api/src/main/resources/openapi.json") { write(json); close() }

--- a/wallet/src/main/scala/org/alephium/wallet/web/WalletServer.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/web/WalletServer.scala
@@ -66,7 +66,9 @@ class WalletServer(
     getWalletLogic
   ).map(route(_))
 
-  lazy val docsRoute = SwaggerUI(openApiJson(walletOpenAPI, maybeApiKey.isEmpty)).map(route(_))
+  lazy val docsRoute = SwaggerUI(
+    openApiJson(walletOpenAPI, maybeApiKey.isEmpty)
+  ).map(route(_))
 }
 
 object WalletServer {

--- a/wallet/src/main/scala/org/alephium/wallet/web/WalletServer.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/web/WalletServer.scala
@@ -66,9 +66,7 @@ class WalletServer(
     getWalletLogic
   ).map(route(_))
 
-  lazy val docsRoute = SwaggerUI(
-    openApiJson(walletOpenAPI, maybeApiKey.isEmpty)
-  ).map(route(_))
+  lazy val docsRoute = SwaggerUI(openApiJson(walletOpenAPI, maybeApiKey.isEmpty)).map(route(_))
 }
 
 object WalletServer {

--- a/wallet/src/main/scala/org/alephium/wallet/web/WalletServer.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/web/WalletServer.scala
@@ -66,7 +66,9 @@ class WalletServer(
     getWalletLogic
   ).map(route(_))
 
-  lazy val docsRoute = SwaggerUI(openApiJson(walletOpenAPI, maybeApiKey.isEmpty)).map(route(_))
+  lazy val docsRoute = SwaggerUI(
+    openApiJson(walletOpenAPI, maybeApiKey.isEmpty, truncateAddresses = true)
+  ).map(route(_))
 }
 
 object WalletServer {


### PR DESCRIPTION
This would render swagger UI on `DevNet` or `TestNet` with functioning addresses so endpoints can be tested. Addresses are truncated only on `MainNet` so that users/devs don't send there their own ALPHs by accident.

Tests are reading truncated `openapi.json` for `MainNet` and they reverse address truncation in order to pass on `DevNet`.

Tested manually by `make assembly` and checking swagger on `DevNet`.