### PR TITLE
Fix sync status subscription

### DIFF
--- a/flow/src/main/scala/org/alephium/flow/network/InterCliqueManager.scala
+++ b/flow/src/main/scala/org/alephium/flow/network/InterCliqueManager.scala
@@ -131,13 +131,9 @@ object InterCliqueManager {
   trait NodeSyncStatus extends BaseActor with EventStream.Subscriber {
     private var nodeSynced: Boolean      = false
     private var firstTimeSynced: Boolean = true
+    subscribeEvent(self, classOf[InterCliqueManager.SyncedResult])
 
     protected def onFirstTimeSynced(): Unit = {}
-
-    override def preStart(): Unit = {
-      super.preStart()
-      subscribeEvent(self, classOf[InterCliqueManager.SyncedResult])
-    }
 
     def updateNodeSyncStatus: Receive = {
       case InterCliqueManager.SyncedResult(isSynced) =>

--- a/flow/src/test/scala/org/alephium/flow/core/FlowUtilsSpec.scala
+++ b/flow/src/test/scala/org/alephium/flow/core/FlowUtilsSpec.scala
@@ -501,7 +501,12 @@ class FlowUtilsSpec extends AlephiumSpec {
     val rhoneReward        = rhoneBlock.coinbaseReward
     val doubleDanubeReward = danubeBlock.coinbaseReward * 2
     val tolerance          = rhoneReward / 20
-    doubleDanubeReward - rhoneReward < tolerance is true
+    val diff = if (doubleDanubeReward > rhoneReward) {
+      doubleDanubeReward - rhoneReward
+    } else {
+      rhoneReward - doubleDanubeReward
+    }
+    diff < tolerance is true
 
     addAndCheck(blockFlow, rhoneBlock, danubeBlock)
   }


### PR DESCRIPTION
Previously, we sent the sync status directly to each actor. In the latest code, we subscribe to the sync status in `preStart` using `eventStream.subscribe`. Since `preStart` runs asynchronously, this could lead to the following issue in integration tests:

1. When the clique starts, `InterCliqueManager` [publishes the sync status](https://github.com/alephium/alephium/blob/a33c3158942826925612ea65e1e6ba2103570ab1/flow/src/main/scala/org/alephium/flow/network/InterCliqueManager.scala#L174)
2. Due to `preStart` running asynchronously, other actors may not have subscribed to the sync status yet
3. `InterCliqueManager` only publishes the sync status [when there is a change in the sync status](https://github.com/alephium/alephium/blob/a33c3158942826925612ea65e1e6ba2103570ab1/flow/src/main/scala/org/alephium/flow/network/InterCliqueManager.scala#L333)

This could prevent other actors from receiving the sync status, so this PR moves the `eventStream.subscribe` call to the actor constructor instead of `preStart`.