### PR TITLE
Fix source index of enum with a default value

### DIFF
--- a/ralph/src/main/scala/org/alephium/ralph/Parser.scala
+++ b/ralph/src/main/scala/org/alephium/ralph/Parser.scala
@@ -661,7 +661,7 @@ abstract class Parser[Ctx <: StatelessContext] {
                     )
                   (
                     nextValue,
-                    Ast.Const[Ctx](Val.U256(nextValue)).atSourceIndex(ident.sourceIndex)
+                    Ast.Const[Ctx](Val.U256(nextValue))
                   )
               }
               (newValue, fields :+ Ast.EnumField(ident, value).atSourceIndex(rawField.sourceIndex))

--- a/ralph/src/test/scala/org/alephium/ralph/ParserSpec.scala
+++ b/ralph/src/test/scala/org/alephium/ralph/ParserSpec.scala
@@ -2726,6 +2726,32 @@ class ParserSpec(fileURI: Option[java.net.URI]) extends AlephiumSpec {
     )
   }
 
+  it should "Enum with default value shouldn't have a source index" in {
+
+    val enumWithDefault = "Second"
+
+    val code =
+      s"""
+         |enum Errors {
+         |  First = 1
+         |  $enumWithDefault
+         |}""".stripMargin
+
+    val enums = parse(code, StatefulParser.enumDef(_)).get.value.fields
+
+    val first  = enums.head
+    val second = enums.last
+
+    first.sourceIndex is Some(SourceIndex(17, 9, fileURI))
+    first.ident.sourceIndex is Some(SourceIndex(17, 5, fileURI))
+    first.value.sourceIndex is Some(SourceIndex(25, 1, fileURI))
+
+    second.sourceIndex is Some(SourceIndex(29, enumWithDefault.size, fileURI))
+    second.ident.sourceIndex is Some(SourceIndex(29, enumWithDefault.size, fileURI))
+    // value source index is not set for default value
+    second.value.sourceIndex is None
+  }
+
   it should "set the origin contract id for constants and functions" in {
     val code =
       s"""

--- a/ralph/src/test/scala/org/alephium/ralph/ParserSpec.scala
+++ b/ralph/src/test/scala/org/alephium/ralph/ParserSpec.scala
@@ -2734,20 +2734,16 @@ class ParserSpec(fileURI: Option[java.net.URI]) extends AlephiumSpec {
       s"""
          |enum Errors {
          |  First = 1
-         |  $enumWithDefault
+         |  $$${enumWithDefault}
          |}""".stripMargin
 
-    val enums = parse(code, StatefulParser.enumDef(_)).get.value.fields
+    val enums = parse(code.replace("$", ""), StatefulParser.enumDef(_)).get.value.fields
 
-    val first  = enums.head
     val second = enums.last
+    val index  = code.indexOf("$")
 
-    first.sourceIndex is Some(SourceIndex(17, 9, fileURI))
-    first.ident.sourceIndex is Some(SourceIndex(17, 5, fileURI))
-    first.value.sourceIndex is Some(SourceIndex(25, 1, fileURI))
-
-    second.sourceIndex is Some(SourceIndex(29, enumWithDefault.size, fileURI))
-    second.ident.sourceIndex is Some(SourceIndex(29, enumWithDefault.size, fileURI))
+    second.sourceIndex is Some(SourceIndex(index, enumWithDefault.size, fileURI))
+    second.ident.sourceIndex is Some(SourceIndex(index, enumWithDefault.size, fileURI))
     // value source index is not set for default value
     second.value.sourceIndex is None
   }


### PR DESCRIPTION
A default value shouldn't have a source index as it's not written in the code.

I tested it with ralph-lsp as the [source issue came from there](https://github.com/alephium/ralph-lsp/issues/452), it works well.

Resolves https://github.com/alephium/alephium/issues/1262