### PR TITLE
Add `RichInput.outputRefTxId`

### DIFF
--- a/api/src/main/resources/openapi.json
+++ b/api/src/main/resources/openapi.json
@@ -4487,7 +4487,8 @@
                                         "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
                                         "amount": "1000000000000000000000"
                                       }
-                                    ]
+                                    ],
+                                    "outputRefTxId": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69"
                                   }
                                 ],
                                 "fixedOutputs": [
@@ -5411,7 +5412,8 @@
                                   "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
                                   "amount": "1000000000000000000000"
                                 }
-                              ]
+                              ],
+                              "outputRefTxId": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69"
                             }
                           ],
                           "fixedOutputs": [
@@ -7795,7 +7797,8 @@
                                 "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
                                 "amount": "1000000000000000000000"
                               }
-                            ]
+                            ],
+                            "outputRefTxId": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69"
                           }
                         ],
                         "fixedOutputs": [
@@ -16665,7 +16668,8 @@
           "unlockScript",
           "attoAlphAmount",
           "address",
-          "tokens"
+          "tokens",
+          "outputRefTxId"
         ],
         "properties": {
           "hint": {
@@ -16693,6 +16697,10 @@
             "items": {
               "$ref": "#/components/schemas/Token"
             }
+          },
+          "outputRefTxId": {
+            "type": "string",
+            "format": "32-byte-hash"
           }
         }
       },
@@ -16820,7 +16828,8 @@
           "key",
           "attoAlphAmount",
           "address",
-          "tokens"
+          "tokens",
+          "outputRefTxId"
         ],
         "properties": {
           "hint": {
@@ -16844,6 +16853,10 @@
             "items": {
               "$ref": "#/components/schemas/Token"
             }
+          },
+          "outputRefTxId": {
+            "type": "string",
+            "format": "32-byte-hash"
           }
         }
       },

--- a/api/src/main/scala/org/alephium/api/EndpointsExamples.scala
+++ b/api/src/main/scala/org/alephium/api/EndpointsExamples.scala
@@ -206,7 +206,8 @@ trait EndpointsExamples extends ErrorExamples {
           unlockScript = unlockupScriptBytes,
           attoAlphAmount = Amount(ALPH.oneAlph),
           address = Address.Asset(lockupScript),
-          tokens
+          tokens,
+          outputRefTxId = txId
         )
       ),
       fixedOutputs = AVector(outputAsset)

--- a/app/src/main/scala/org/alephium/app/ServerUtils.scala
+++ b/app/src/main/scala/org/alephium/app/ServerUtils.scala
@@ -632,8 +632,14 @@ class ServerUtils(implicit
       for {
         txOutputOpt <- wrapResult(blockFlow.getTxOutput(contractOutputRef, spentBlockHash))
         richInput <- txOutputOpt match {
-          case Some(txOutput) =>
-            Right(RichInput.from(contractOutputRef, txOutput.asInstanceOf[ProtocolContractOutput]))
+          case Some((txId, txOutput)) =>
+            Right(
+              RichInput.from(
+                contractOutputRef,
+                txOutput.asInstanceOf[ProtocolContractOutput],
+                txId
+              )
+            )
           case None =>
             Left(notFound(s"Transaction output for contract output reference ${contractOutputRef}"))
         }
@@ -651,8 +657,8 @@ class ServerUtils(implicit
       for {
         txOutputOpt <- wrapResult(blockFlow.getTxOutput(assetInput.outputRef, spentBlockHash))
         richInput <- txOutputOpt match {
-          case Some(txOutput) =>
-            Right(RichInput.from(assetInput, txOutput.asInstanceOf[AssetOutput]))
+          case Some((txId, txOutput)) =>
+            Right(RichInput.from(assetInput, txOutput.asInstanceOf[AssetOutput], txId))
           case None =>
             Left(notFound(s"Transaction output for asset output reference ${assetInput.outputRef}"))
         }


### PR DESCRIPTION
This field is required by Explorer-Backend for sycing with rich blocks, as it's used by FE to ease navigation between transactions.