### PR TITLE
Unify and clarify wallet balance model across API and wallet code

### DIFF
--- a/api/src/main/resources/openapi.json
+++ b/api/src/main/resources/openapi.json
@@ -895,7 +895,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Balances"
+                  "$ref": "#/components/schemas/WalletBalance"
                 },
                 "example": {
                   "totalBalance": "10000000000000000000",
@@ -903,10 +903,13 @@
                   "balances": [
                     {
                       "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
-                      "balance": "10000000000000000000",
-                      "balanceHint": "10 ALPH",
-                      "lockedBalance": "0",
-                      "lockedBalanceHint": "0 ALPH"
+                      "balance": {
+                        "balance": "10000000000000000000",
+                        "balanceHint": "10 ALPH",
+                        "lockedBalance": "5000000000000000000",
+                        "lockedBalanceHint": "5 ALPH",
+                        "utxoNum": 3
+                      }
                     }
                   ]
                 }
@@ -13638,39 +13641,6 @@
           }
         }
       },
-      "AddressBalance": {
-        "title": "AddressBalance",
-        "type": "object",
-        "required": [
-          "address",
-          "balance",
-          "balanceHint",
-          "lockedBalance",
-          "lockedBalanceHint"
-        ],
-        "properties": {
-          "address": {
-            "type": "string",
-            "format": "address"
-          },
-          "balance": {
-            "type": "string",
-            "format": "uint256"
-          },
-          "balanceHint": {
-            "type": "string",
-            "format": "x.x ALPH"
-          },
-          "lockedBalance": {
-            "type": "string",
-            "format": "uint256"
-          },
-          "lockedBalanceHint": {
-            "type": "string",
-            "format": "x.x ALPH"
-          }
-        }
-      },
       "AddressInfo": {
         "title": "AddressInfo",
         "type": "object",
@@ -13857,31 +13827,6 @@
           "utxoNum": {
             "type": "integer",
             "format": "int32"
-          }
-        }
-      },
-      "Balances": {
-        "title": "Balances",
-        "type": "object",
-        "required": [
-          "totalBalance",
-          "totalBalanceHint",
-          "balances"
-        ],
-        "properties": {
-          "totalBalance": {
-            "type": "string",
-            "format": "uint256"
-          },
-          "totalBalanceHint": {
-            "type": "string",
-            "format": "x.x ALPH"
-          },
-          "balances": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AddressBalance"
-            }
           }
         }
       },
@@ -17944,6 +17889,48 @@
           "publicKey": {
             "type": "string",
             "format": "public-key"
+          }
+        }
+      },
+      "WalletAddressBalance": {
+        "title": "WalletAddressBalance",
+        "type": "object",
+        "required": [
+          "address",
+          "balance"
+        ],
+        "properties": {
+          "address": {
+            "type": "string",
+            "format": "address"
+          },
+          "balance": {
+            "$ref": "#/components/schemas/Balance"
+          }
+        }
+      },
+      "WalletBalance": {
+        "title": "WalletBalance",
+        "type": "object",
+        "required": [
+          "totalBalance",
+          "totalBalanceHint",
+          "balances"
+        ],
+        "properties": {
+          "totalBalance": {
+            "type": "string",
+            "format": "uint256"
+          },
+          "totalBalanceHint": {
+            "type": "string",
+            "format": "x.x ALPH"
+          },
+          "balances": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WalletAddressBalance"
+            }
           }
         }
       },

--- a/integration/src/test/scala/org/alephium/app/SweepTest.scala
+++ b/integration/src/test/scala/org/alephium/app/SweepTest.scala
@@ -34,11 +34,11 @@ abstract class SweepTest(isMiner: Boolean) extends AlephiumActorSpec {
       val balance = request[Balance](getBalance(activeAddress.toBase58), restPort)
       balance.balance.value is 0
 
-      val balances = request[Balances](walletBalances(walletName), restPort)
+      val balances = request[WalletBalance](walletBalances(walletName), restPort)
 
       // all other addresses are not swept
       addresses.filterNot(_.equals(activeAddress)).foreach { addr =>
-        balances.balances.find(_.address.equals(addr)).value.balance.value is ALPH.alph(1)
+        balances.balances.find(_.address.equals(addr)).value.balance.balance.value is ALPH.alph(1)
       }
     }
 
@@ -56,12 +56,12 @@ abstract class SweepTest(isMiner: Boolean) extends AlephiumActorSpec {
     transfer.results.length is numberOfAddresses
 
     eventually {
-      val balances = request[Balances](walletBalances(walletName), restPort)
+      val balances = request[WalletBalance](walletBalances(walletName), restPort)
       balances.totalBalance.value is ALPH.alph(0)
 
       // all addresses are swept
       addresses.foreach { addr =>
-        balances.balances.find(_.address.equals(addr)).value.balance.value is ALPH.alph(0)
+        balances.balances.find(_.address.equals(addr)).value.balance.balance.value is ALPH.alph(0)
       }
     }
 
@@ -114,13 +114,13 @@ abstract class SweepTest(isMiner: Boolean) extends AlephiumActorSpec {
         )
     }
 
-    val balances = request[Balances](walletBalances(walletName), restPort)
+    val balances = request[WalletBalance](walletBalances(walletName), restPort)
     balances.totalBalance.value is ALPH.alph(1) * numberOfAddresses
 
     request[Balance](getBalance(activeAddress.toBase58), restPort).balance.value is ALPH.alph(1)
 
     addresses.foreach { address =>
-      balances.balances.find(_.address.equals(address)).value.balance.value is ALPH.alph(1)
+      balances.balances.find(_.address.equals(address)).value.balance.balance.value is ALPH.alph(1)
     }
   }
 }

--- a/wallet/src/main/scala/org/alephium/wallet/api/WalletEndpoints.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/api/WalletEndpoints.scala
@@ -93,10 +93,10 @@ trait WalletEndpoints
       .in(query[String]("password"))
       .summary("Delete your wallet file (can be recovered with your mnemonic)")
 
-  val getBalances: BaseEndpoint[String, Balances] =
+  val getBalances: BaseEndpoint[String, WalletBalance] =
     wallet.get
       .in("balances")
-      .out(jsonBodyWithAlph[Balances])
+      .out(jsonBodyWithAlph[WalletBalance])
       .summary("Get your total balance")
 
   val transfer: BaseEndpoint[(String, Transfer), TransferResult] =

--- a/wallet/src/main/scala/org/alephium/wallet/api/WalletExamples.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/api/WalletExamples.scala
@@ -19,7 +19,7 @@ package org.alephium.wallet.api
 import sttp.tapir.EndpointIO.Example
 
 import org.alephium.api.EndpointsExamples
-import org.alephium.api.model.Amount
+import org.alephium.api.model.Balance
 import org.alephium.crypto.wallet.Mnemonic
 import org.alephium.protocol.PublicKey
 import org.alephium.protocol.config.GroupConfig
@@ -114,18 +114,23 @@ trait WalletExamples extends EndpointsExamples {
       )
     )
 
-  implicit val balancesExamples: List[Example[Balances]] =
+  implicit val balancesExamples: List[Example[WalletBalance]] =
     simpleExample(
-      Balances(
+      WalletBalance(
         balance,
         balance.hint,
         AVector(
-          Balances.AddressBalance(
+          WalletBalance.WalletAddressBalance(
             address,
-            balance,
-            balance.hint,
-            Amount.Zero,
-            Amount.Zero.hint
+            Balance(
+              balance,
+              balance.hint,
+              halfBalance,
+              halfBalance.hint,
+              None,
+              None,
+              utxoNum = 3
+            )
           )
         )
       )

--- a/wallet/src/main/scala/org/alephium/wallet/api/model/WalletBalance.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/api/model/WalletBalance.scala
@@ -16,43 +16,36 @@
 
 package org.alephium.wallet.api.model
 
-import org.alephium.api.model.Amount
+import org.alephium.api.model.{Amount, Balance}
 import org.alephium.protocol.model.Address
 import org.alephium.util.AVector
 
-final case class Balances(
+final case class WalletBalance(
     totalBalance: Amount,
     totalBalanceHint: Amount.Hint,
-    balances: AVector[Balances.AddressBalance]
+    balances: AVector[WalletBalance.WalletAddressBalance]
 )
 
-object Balances {
-  def from(totalBalance: Amount, balances: AVector[Balances.AddressBalance]): Balances = Balances(
+object WalletBalance {
+  def from(totalBalance: Amount, balances: AVector[WalletBalance.WalletAddressBalance]): WalletBalance = WalletBalance(
     totalBalance,
     totalBalance.hint,
     balances
   )
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-  final case class AddressBalance(
+  final case class WalletAddressBalance(
       address: Address.Asset,
-      balance: Amount,
-      balanceHint: Amount.Hint,
-      lockedBalance: Amount,
-      lockedBalanceHint: Amount.Hint
+      balance: Balance
   )
 
-  object AddressBalance {
+  object WalletAddressBalance {
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
     def from(
         address: Address.Asset,
-        balance: Amount,
-        lockedBalance: Amount
-    ): AddressBalance = AddressBalance(
+        balance: Balance
+    ): WalletAddressBalance = WalletAddressBalance(
       address,
-      balance,
-      balance.hint,
-      lockedBalance,
-      lockedBalance.hint
+      balance
     )
   }
 }

--- a/wallet/src/main/scala/org/alephium/wallet/json/ModelCodecs.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/json/ModelCodecs.scala
@@ -31,9 +31,9 @@ trait ModelCodecs extends ApiModelCodec {
 
   implicit val minerAddressesInfoRW: RW[MinerAddressesInfo] = macroRW
 
-  implicit val addressBalanceRW: RW[Balances.AddressBalance] = macroRW
+  implicit val addressBalanceRW: RW[WalletBalance.WalletAddressBalance] = macroRW
 
-  implicit val balancesRW: RW[Balances] = macroRW
+  implicit val balancesRW: RW[WalletBalance] = macroRW
 
   implicit val changeActiveAddressRW: RW[ChangeActiveAddress] = macroRW
 

--- a/wallet/src/main/scala/org/alephium/wallet/service/WalletService.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/service/WalletService.scala
@@ -32,7 +32,6 @@ import sttp.model.StatusCode
 import org.alephium.api.{model => api}
 import org.alephium.api.ApiError
 import org.alephium.api.model.{
-  Amount,
   BuildGrouplessTransferTxResult,
   BuildSimpleTransferTxResult,
   Destination,
@@ -79,7 +78,7 @@ trait WalletService extends Service {
   def deleteWallet(wallet: String, password: String): Either[WalletError, Unit]
   def getBalances(
       wallet: String
-  ): Future[Either[WalletError, AVector[(Address.Asset, Amount, Amount)]]]
+  ): Future[Either[WalletError, AVector[(Address.Asset, api.Balance)]]]
   def getAddresses(wallet: String): Either[WalletError, Addresses]
   def getAddressInfo(wallet: String, address: Address.Asset): Either[WalletError, AddressInfo]
   def getMinerAddresses(
@@ -340,7 +339,7 @@ object WalletService {
 
     override def getBalances(
         wallet: String
-    ): Future[Either[WalletError, AVector[(Address.Asset, Amount, Amount)]]] =
+    ): Future[Either[WalletError, AVector[(Address.Asset, api.Balance)]]] =
       withAddressesFut(wallet) { case (_, addresses) =>
         Future
           .sequence(addresses.toSeq.map(getBalance))
@@ -585,12 +584,12 @@ object WalletService {
 
     private def getBalance(
         address: Address.Asset
-    ): Future[Either[WalletError, (Address.Asset, Amount, Amount)]] = {
+    ): Future[Either[WalletError, (Address.Asset, api.Balance)]] = {
       blockFlowClient
         .fetchBalance(api.Address.fromProtocol(address))
         .map(
-          _.map { case (amount, lockedAmount) =>
-            (address, amount, lockedAmount)
+          _.map { balance =>
+            (address, balance)
           }.left.map(error => BlockFlowClientError(error))
         )
     }

--- a/wallet/src/main/scala/org/alephium/wallet/web/BlockFlowClient.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/web/BlockFlowClient.scala
@@ -33,7 +33,7 @@ import org.alephium.util.{AVector, Duration, TimeStamp}
 trait BlockFlowClient {
   def fetchBalance(
       address: api.Address
-  ): Future[Either[ApiError[_ <: StatusCode], (Amount, Amount)]]
+  ): Future[Either[ApiError[_ <: StatusCode], api.Balance]]
   def prepareTransaction(
       fromPublicKey: PublicKey,
       destinations: AVector[Destination],
@@ -109,7 +109,7 @@ object BlockFlowClient {
 
     def fetchBalance(
         address: api.Address
-    ): Future[Either[ApiError[_ <: StatusCode], (Amount, Amount)]] =
+    ): Future[Either[ApiError[_ <: StatusCode], api.Balance]] =
       address.lockupScript match {
         case api.Address.CompleteLockupScript(_: LockupScript.P2C) =>
           Future.successful(
@@ -128,10 +128,8 @@ object BlockFlowClient {
     private def getBalance(
         address: api.Address,
         groupIndex: GroupIndex
-    ): Future[Either[ApiError[_ <: StatusCode], (Amount, Amount)]] = {
-      requestFromGroup(groupIndex, getBalance, (address, Some(true))).map(
-        _.map(res => (res.balance, res.lockedBalance))
-      )
+    ): Future[Either[ApiError[_ <: StatusCode], api.Balance]] = {
+      requestFromGroup(groupIndex, getBalance, (address, Some(true)))
     }
 
     def prepareTransaction(

--- a/wallet/src/main/scala/org/alephium/wallet/web/WalletEndpointsLogic.scala
+++ b/wallet/src/main/scala/org/alephium/wallet/web/WalletEndpointsLogic.scala
@@ -89,15 +89,15 @@ trait WalletEndpointsLogic extends WalletEndpoints {
       .getBalances(wallet)
       .map(_.map { balances =>
         val totalBalance =
-          Amount(balances.map { case (_, amount, _) => amount }.fold(U256.Zero) {
+          Amount(balances.map { case (_, balance) => balance.balance }.fold(U256.Zero) {
             case (acc, amount) =>
               acc.addUnsafe(amount.value)
           })
-        val balancesPerAddress = balances.map { case (address, amount, lockedAmount) =>
-          model.Balances
-            .AddressBalance(address, amount, amount.hint, lockedAmount, lockedAmount.hint)
+        val balancesPerAddress = balances.map { case (address, balance) =>
+          model.WalletBalance
+            .WalletAddressBalance(address, balance)
         }
-        model.Balances(totalBalance, totalBalance.hint, balancesPerAddress)
+        model.WalletBalance(totalBalance, totalBalance.hint, balancesPerAddress)
       }.left.map(toApiError))
   }
 

--- a/wallet/src/test/scala/org/alephium/wallet/json/ModelCodecsSpec.scala
+++ b/wallet/src/test/scala/org/alephium/wallet/json/ModelCodecsSpec.scala
@@ -18,6 +18,7 @@ package org.alephium.wallet.json
 
 import org.scalatest.Assertion
 
+import org.alephium.api.{model => api}
 import org.alephium.api.model.{Amount, Destination}
 import org.alephium.crypto.wallet.Mnemonic
 import org.alephium.json.Json._
@@ -77,16 +78,25 @@ class ModelCodecsSpec extends AlephiumSpec with ModelCodecs {
 
   it should "Balances.AddressBalance" in {
     val json =
-      s"""{"address":"$address","balance":"$balance","balanceHint":"1 ALPH","lockedBalance":"$lockedBalance","lockedBalanceHint":"2 ALPH"}"""
-    val addressBalance = Balances.AddressBalance.from(address, balance, lockedBalance)
+      s"""{"address":"$address","balance":{"balance":"$balance","balanceHint":"1 ALPH","lockedBalance":"$lockedBalance","lockedBalanceHint":"2 ALPH","utxoNum":1}}"""
+    val addressBalance = WalletBalance.WalletAddressBalance.from(
+      address,
+      api.Balance.from(balance, lockedBalance, None, None, 1)
+    )
     check(addressBalance, json)
   }
 
   it should "Balances" in {
     val json =
-      s"""{"totalBalance":"$balance","totalBalanceHint":"1 ALPH","balances":[{"address":"$address","balance":"$balance","balanceHint":"1 ALPH","lockedBalance":"$lockedBalance","lockedBalanceHint":"2 ALPH"}]}"""
+      s"""{"totalBalance":"$balance","totalBalanceHint":"1 ALPH","balances":[{"address":"$address","balance":{"balance":"$balance","balanceHint":"1 ALPH","lockedBalance":"$lockedBalance","lockedBalanceHint":"2 ALPH","utxoNum":1}}]}"""
     val balances =
-      Balances.from(balance, AVector(Balances.AddressBalance.from(address, balance, lockedBalance)))
+      WalletBalance.from(
+        balance,
+        AVector(
+          WalletBalance.WalletAddressBalance
+            .from(address, api.Balance.from(balance, lockedBalance, None, None, 1))
+        )
+      )
     check(balances, json)
   }
 


### PR DESCRIPTION
The previous balance model naming and structure (e.g., `Balances`, `AddressBalance`) were confusing and inconsistent with the rest of the codebase. This commit introduces a unified and clearer model for wallet balances by:

- Renaming and restructuring the wallet balance models to use `WalletBalance` and `WalletAddressBalance`.
- Ensuring the wallet API now uses the same `Balance` model as the rest of the code, removing redundant or obsolete types.
- Updating all relevant endpoints, codecs, example data, and tests to use the new unified model.
- Improving overall clarity and maintainability by having a single, consistent representation of balance information.

This unification removes ambiguity, makes the codebase easier to understand, and ensures future extensions to the balance model are straightforward and coherent across modules.

### **Important**

This is a breaking change for the wallet API