### PR TITLE
Expand security policy with Bug Bounty Program details

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,79 @@
+# Security Policy
+
+Alephium takes the security of its network and infrastructure seriously. We appreciate the security community's efforts in helping us keep Alephium and its users safe.
+
+## Bug Bounty Program
+
+Alephium operates a Bug Bounty & Responsible Disclosure program that rewards researchers who report vulnerabilities responsibly. The full program rules, eligibility criteria, and reward terms are documented at:
+
+**[Alephium Bug Bounty Program](https://github.com/alephium/community/blob/master/BugBounty.md)**
+
+Please read the program rules in full before reporting.
+
+## Scope
+
+The bug bounty program covers the entire operational Alephium environment, including (but not limited to) the following repositories:
+
+- [alephium/alephium](https://github.com/alephium/alephium) — Full node / protocol
+- [alephium/alephium-frontend](https://github.com/alephium/alephium-frontend) — Frontend applications
+- [alephium/extension-wallet](https://github.com/alephium/extension-wallet) — Browser extension wallet
+- [alephium/wormhole-fork](https://github.com/alephium/wormhole-fork) — Bridge
+- [alephium/ledger-alephium](https://github.com/alephium/ledger-alephium) — Ledger integration
+- [alephium/alephium-dex](https://github.com/alephium/alephium-dex) — DEX proof of concept
+- [alephium/alephium-nft](https://github.com/alephium/alephium-nft) — NFT marketplace proof of concept
+- [alephium/alephium-web3](https://github.com/alephium/alephium-web3) — Web3 SDK
+- [alephium/explorer-backend](https://github.com/alephium/explorer-backend) — Explorer backend
+- [alephium/www](https://github.com/alephium/www) — Website
+
+Bugs found in any other Alephium-related repository that put user funds at risk will also be considered in scope.
+
+**Out of scope:**
+
+- Third-party contracts outside Alephium's direct control
+- Bugs in third-party contracts or apps utilizing Alephium code
+
+## How to Report a Vulnerability
+
+Please report vulnerabilities through **one** of the following private channels. Do **not** disclose the issue publicly (issues, discussions, pull requests, social media, etc.) until Alephium has acknowledged, resolved the issue, and authorized public disclosure.
+
+### Option 1 — Email (primary channel)
+
+Send your report to **bugbounty@alephium.org**.
+
+An acknowledgment will be issued within 2 business days.
+
+### Option 2 — GitHub Private Vulnerability Reporting
+
+You may alternatively submit your report through GitHub's Private Vulnerability Reporting feature on this repository:
+
+**[Report a vulnerability](https://github.com/alephium/alephium/security/advisories/new)**
+
+This channel keeps your report private until a fix is published. Once the advisory is published, you can be publicly credited for the discovery — useful for researchers who prefer in-platform recognition. The same disclosure rules apply: do not share the report outside this private channel until the advisory is published.
+
+## What to Include in Your Report
+
+A comprehensive report helps us triage and reward faster. Please include:
+
+- The conditions required to reproduce the vulnerability
+- Steps to reproduce, ideally a proof of concept
+- Affected component(s), commit hash, or release version
+- Potential impact and exploitation scenarios
+- Your contact details and whether you wish to be publicly credited
+
+## Disclosure Timeline
+
+- Reports must be submitted **within 24 hours** of discovery, as required by the Bug Bounty program.
+- Alephium will acknowledge receipt within **2 business days**.
+- Public disclosure may only occur after Alephium has resolved the issue and authorized release.
+
+## Recognition
+
+Researchers who report a unique, previously unreported vulnerability and maintain confidentiality until it is resolved may opt for public recognition. If you submit through GitHub Private Vulnerability Reporting, recognition can be issued directly on the published security advisory.
+
+## Rewards
+
+Rewards are determined by Alephium based on the risk level and exploitability of the bug, as described in the [full program rules](https://github.com/alephium/community/blob/master/BugBounty.md).
+
+---
+
+Thank you for helping keep Alephium and its users safe.


### PR DESCRIPTION
# Add SECURITY.md and enable Private Vulnerability Reporting

## Why

The Alephium bug bounty program already exists ([`community/BugBounty.md`](https://github.com/alephium/community/blob/master/BugBounty.md)), but it is not discoverable from this repository. A researcher who finds a vulnerability in `alephium/alephium` has no obvious in-repo signal pointing them to the right disclosure channel — they have to know that the bounty page lives in a separate `community` repo.

GitHub conventions expect a `SECURITY.md` at the root of the repository:

- GitHub surfaces it under the **Security** tab.
- It populates the "Report a vulnerability" prompt.
- It is shown as a hint when a researcher opens a new issue.

A `SECURITY.md` is therefore the lowest-effort, highest-visibility place to direct researchers to the existing bounty program.

## What this PR does

- Adds `SECURITY.md` at the repository root.
- The new policy:
  - Links to the existing bug bounty program rules in `alephium/community`.
  - Documents the in-scope repositories, out-of-scope items, disclosure timeline, and rewards mechanism (consistent with `BugBounty.md` — no rules are introduced or changed).
  - Offers researchers **two** private disclosure channels:
    1. The existing email — `bugbounty@alephium.org` (unchanged primary channel).
    2. **GitHub Private Vulnerability Reporting (PVR)** — a private security advisory raised directly on this repository.

## Action required from maintainers — enable Private Vulnerability Reporting

For the second disclosure channel in `SECURITY.md` to work, a repository administrator needs to enable Private Vulnerability Reporting on this repository. Steps:

1. Open the repository on GitHub.
2. Go to **Settings → Security → Advanced Security**.
3. Locate **Private vulnerability reporting**.
4. Click **Enable**.

GitHub reference: <https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability>

Ideally, the same change is applied to the other in-scope `alephium/*` repositories listed in `SECURITY.md` and `BugBounty.md` so that the channel is consistent across the project.

> The `SECURITY.md` in this PR already handles the case where PVR is not yet enabled — the *Report a vulnerability* link will simply not be active, and the file explicitly tells researchers to fall back to email in that case. Merging is therefore safe even if PVR is enabled later.

### Why also offer PVR (and not just keep email)

The bug bounty rules already allow public recognition for researchers who follow responsible disclosure: *"Any individual who reports a unique, previously unreported vulnerability that leads to a code alteration or configuration change, and maintains its confidentiality until its resolution by our engineers, may opt for public recognition for their contribution."*

PVR operationalizes that option in a GitHub-native way:

- The report stays private until a fix is shipped.
- Once the advisory is published, the researcher is credited on the advisory page (`https://github.com/alephium/alephium/security/advisories`), with a permanent, citable URL.
- This gives whitehats in-platform recognition they can link to from a portfolio, conference talk, or CV — without changing the bounty payout, the email channel, or any of the existing rules in `BugBounty.md`.

Researchers who prefer not to be publicly credited can simply keep using email; nothing about the existing flow is removed or weakened.

## Notes

- This PR does not modify the bug bounty rules. [`community/BugBounty.md`](https://github.com/alephium/community/blob/master/BugBounty.md) remains authoritative; `SECURITY.md` only summarizes and links to it.
- If maintainers prefer to keep email as the sole channel, removing Option 2 from `SECURITY.md` is a small edit and the rest of the policy is still useful.

## Checklist

- [x] `SECURITY.md` added at the repository root.
- [ ] Maintainer enables Private Vulnerability Reporting on `alephium/alephium` (**Settings → Security → Advanced Security → Private vulnerability reporting → Enable**).
- [ ] Publish reward ranges per severity tier
- [ ] (Optional) Maintainer enables PVR on the other in-scope `alephium/*` repositories.
- [ ] (Optional) Mirror `SECURITY.md` on the other in-scope `alephium/*` repositories.
